### PR TITLE
refactor: rename proxclt → proxctl (breaking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
       - name: go test
         run: go test -race -coverprofile=coverage.out ./...
       - name: go build
-        run: CGO_ENABLED=0 go build -trimpath -o /tmp/proxclt ./cmd/proxclt
+        run: CGO_ENABLED=0 go build -trimpath -o /tmp/proxctl ./cmd/proxctl
       - name: sanity check
-        run: /tmp/proxclt version
+        run: /tmp/proxctl version

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-/proxclt
+/proxctl
 /bin/
 /dist/
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,24 +1,24 @@
 version: 2
 
-project_name: proxclt
+project_name: proxctl
 
 before:
   hooks:
     - go mod tidy
 
 builds:
-  - id: proxclt
-    main: ./cmd/proxclt
-    binary: proxclt
+  - id: proxctl
+    main: ./cmd/proxctl
+    binary: proxctl
     env:
       - CGO_ENABLED=0
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     ldflags:
       - -s -w
-      - -X github.com/itunified-io/proxclt/pkg/version.Version={{.Version}}
-      - -X github.com/itunified-io/proxclt/pkg/version.Commit={{.ShortCommit}}
-      - -X github.com/itunified-io/proxclt/pkg/version.Date={{.Date}}
+      - -X github.com/itunified-io/proxctl/pkg/version.Version={{.Version}}
+      - -X github.com/itunified-io/proxctl/pkg/version.Commit={{.ShortCommit}}
+      - -X github.com/itunified-io/proxctl/pkg/version.Date={{.Date}}
 
 archives:
   - id: default
@@ -41,25 +41,25 @@ changelog:
       - "^chore:"
 
 brews:
-  - name: proxclt
+  - name: proxctl
     repository:
       owner: itunified-io
       name: homebrew-tap
-    homepage: "https://github.com/itunified-io/proxclt"
+    homepage: "https://github.com/itunified-io/proxctl"
     description: "Proxmox VM provisioning CLI — kickstart, lifecycle, workflows"
     license: "AGPL-3.0"
     install: |
-      bin.install "proxclt"
+      bin.install "proxctl"
 
 dockers:
   - image_templates:
-      - "ghcr.io/itunified-io/proxclt:{{ .Version }}-amd64"
+      - "ghcr.io/itunified-io/proxctl:{{ .Version }}-amd64"
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
     extra_files: [LICENSE]
   - image_templates:
-      - "ghcr.io/itunified-io/proxclt:{{ .Version }}-arm64"
+      - "ghcr.io/itunified-io/proxctl:{{ .Version }}-arm64"
     use: buildx
     goarch: arm64
     build_flag_templates:
@@ -67,11 +67,11 @@ dockers:
     extra_files: [LICENSE]
 
 docker_manifests:
-  - name_template: "ghcr.io/itunified-io/proxclt:{{ .Version }}"
+  - name_template: "ghcr.io/itunified-io/proxctl:{{ .Version }}"
     image_templates:
-      - "ghcr.io/itunified-io/proxclt:{{ .Version }}-amd64"
-      - "ghcr.io/itunified-io/proxclt:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/itunified-io/proxclt:latest"
+      - "ghcr.io/itunified-io/proxctl:{{ .Version }}-amd64"
+      - "ghcr.io/itunified-io/proxctl:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/itunified-io/proxctl:latest"
     image_templates:
-      - "ghcr.io/itunified-io/proxclt:{{ .Version }}-amd64"
-      - "ghcr.io/itunified-io/proxclt:{{ .Version }}-arm64"
+      - "ghcr.io/itunified-io/proxctl:{{ .Version }}-amd64"
+      - "ghcr.io/itunified-io/proxctl:{{ .Version }}-arm64"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-All notable changes to proxclt are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
+All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
+
+## v2026.04.11.3 — 2026-04-19
+
+### Changed (BREAKING)
+- Renamed tool from `proxclt` → `proxctl` (per user request, ADR follow-up pending)
+- Go module path: `github.com/itunified-io/proxctl`
+- Binary: `proxctl`
+- Config/state dir: `~/.proxctl/`
+- Env vars: `PROXCTL_*`
+- Repo: `itunified-io/proxctl` (GitHub auto-redirects from old URL)
 
 ## v2026.04.11.2 — 2026-04-19
 
@@ -10,22 +20,22 @@ All notable changes to proxclt are documented here. Format: CalVer (`YYYY.MM.DD.
 - `pkg/proxmox` (83.8% coverage): core REST client with token auth + task polling, VM CRUD + list + status, storage list + ISO upload, snapshot CRUD + rollback, first-boot ISO attach + SetBootOrder + ConfigureFirstBoot (#1)
 - `pkg/kickstart` (69.5% coverage): Go text/template + sprig renderer, templates for OL8/OL9/Ubuntu 22.04 (base + common partials), xorriso/mkisofs ISO builder (#1)
 - `pkg/workflow` (53.7% coverage): SingleVMWorkflow with Plan → Apply → Verify → Rollback + Up/Down helpers, dry-run support (#1)
-- `internal/root/clientutil.go`: Proxmox client loader from `~/.proxclt/config.yaml` (kubectl-style contexts) with env-var fallback
+- `internal/root/clientutil.go`: Proxmox client loader from `~/.proxctl/config.yaml` (kubectl-style contexts) with env-var fallback
 - CLI handlers wired for real: `config validate|render|schema`, `vm create|start|stop|reboot|delete|list|status`, `snapshot create|restore|list|delete`, `kickstart generate|build-iso|upload|distros`, `boot configure-first-boot|eject-iso`, `workflow plan|up|down|status|verify`
 
 ### Verified
 
 - `go build ./...`, `go vet ./...`, `staticcheck ./...`, `go test ./...` all clean
-- `proxclt config validate <env.yaml>` roundtrip green
-- `proxclt kickstart distros` lists 3 supported distros
+- `proxctl config validate <env.yaml>` roundtrip green
+- `proxctl kickstart distros` lists 3 supported distros
 
 ## v2026.04.11.1 — 2026-04-22
 
 ### Added
 
-- Initial scaffold from Phase 1 of the proxclt + linuxctl plan
-  (`itunified-io/infrastructure` docs/plans/024-proxclt-design.md).
-- Go module `github.com/itunified-io/proxclt` on Go 1.23.
+- Initial scaffold from Phase 1 of the proxctl + linuxctl plan
+  (`itunified-io/infrastructure` docs/plans/024-proxctl-design.md).
+- Go module `github.com/itunified-io/proxctl` on Go 1.23.
 - Cobra command tree covering 9 subcommand groups:
   `config`, `env`, `vm`, `snapshot`, `kickstart`, `boot`, `workflow`, `license`, `version`.
   Every leaf subcommand returns `not implemented yet (scaffold)` — real logic lands in Phase 2+.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.20 AS base
 RUN apk add --no-cache ca-certificates tzdata xorriso
-COPY proxclt /usr/local/bin/proxclt
-ENTRYPOINT ["proxclt"]
+COPY proxctl /usr/local/bin/proxctl
+ENTRYPOINT ["proxctl"]
 CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-BINARY := proxclt
-PKG    := github.com/itunified-io/proxclt
+BINARY := proxctl
+PKG    := github.com/itunified-io/proxctl
 VERSION ?= dev
 COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
 DATE    := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -12,7 +12,7 @@ LDFLAGS := -s -w \
 .PHONY: build test lint vet staticcheck docs clean
 
 build:
-	CGO_ENABLED=0 go build -trimpath -ldflags="$(LDFLAGS)" -o bin/$(BINARY) ./cmd/proxclt
+	CGO_ENABLED=0 go build -trimpath -ldflags="$(LDFLAGS)" -o bin/$(BINARY) ./cmd/proxctl
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# proxclt
+# proxctl
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Go Version](https://img.shields.io/badge/go-1.23%2B-00ADD8.svg)](https://go.dev/)
 
-**proxclt** is a single-binary Go CLI for Proxmox VM provisioning — kickstart rendering, ISO remastering, VM lifecycle, snapshots, and multi-VM workflow orchestration.
+**proxctl** is a single-binary Go CLI for Proxmox VM provisioning — kickstart rendering, ISO remastering, VM lifecycle, snapshots, and multi-VM workflow orchestration.
 
-> Status: **Phase 1 scaffold.** Command tree + license gate + SQLite state are stubs. Real implementation lands in Phases 2–5. See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private) for the roadmap.
+> Status: **Phase 1 scaffold.** Command tree + license gate + SQLite state are stubs. Real implementation lands in Phases 2–5. See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private) for the roadmap.
 
 ## Install
 
@@ -13,23 +13,23 @@ See [`docs/installation.md`](docs/installation.md) for details. Quick options:
 
 ```bash
 # Homebrew (post-launch)
-brew install itunified-io/tap/proxclt
+brew install itunified-io/tap/proxctl
 
 # Direct binary
-curl -L https://github.com/itunified-io/proxclt/releases/latest/download/proxclt-$(uname -s)-$(uname -m).tar.gz | tar xz
+curl -L https://github.com/itunified-io/proxctl/releases/latest/download/proxctl-$(uname -s)-$(uname -m).tar.gz | tar xz
 
 # Build from source
-git clone https://github.com/itunified-io/proxclt.git && cd proxclt && make build
-./bin/proxclt version
+git clone https://github.com/itunified-io/proxctl.git && cd proxctl && make build
+./bin/proxctl version
 ```
 
 ## Quick start
 
 ```bash
-proxclt --help
-proxclt version
-proxclt config get-contexts
-proxclt env list
+proxctl --help
+proxctl version
+proxctl config get-contexts
+proxctl env list
 ```
 
 Full user guide: [`docs/user-guide.md`](docs/user-guide.md).

--- a/cmd/proxclt/main.go
+++ b/cmd/proxclt/main.go
@@ -1,9 +1,0 @@
-// proxclt — Proxmox VM provisioning CLI.
-// See docs/ and design doc 024-proxclt-design.md for the full spec.
-package main
-
-import "github.com/itunified-io/proxclt/internal/root"
-
-func main() {
-	root.Execute()
-}

--- a/cmd/proxctl/main.go
+++ b/cmd/proxctl/main.go
@@ -1,0 +1,9 @@
+// proxctl — Proxmox VM provisioning CLI.
+// See docs/ and design doc 024-proxctl-design.md for the full spec.
+package main
+
+import "github.com/itunified-io/proxctl/internal/root"
+
+func main() {
+	root.Execute()
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
-# proxclt documentation
+# proxctl documentation
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,5 @@
 # Architecture
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,6 +2,6 @@
 
 > **Note:** this file is auto-generated from Cobra via `make docs` in Phase 2+.
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,5 +1,5 @@
 # Configuration reference
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,5 @@
 # Contributing
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/docs/distro-guide.md
+++ b/docs/distro-guide.md
@@ -1,5 +1,5 @@
 # Distro guide
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,5 @@
 # Installation
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,5 +1,5 @@
 # Licensing
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/docs/profile-guide.md
+++ b/docs/profile-guide.md
@@ -1,5 +1,5 @@
 # Profile guide (Business tier)
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,5 +1,5 @@
 # Quick start
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,5 @@
 # Troubleshooting
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,5 +1,5 @@
 # User guide
 
-_Phase 1 scaffold — full content lands in Phase 7 of the proxclt + linuxctl plan._
+_Phase 1 scaffold — full content lands in Phase 7 of the proxctl + linuxctl plan._
 
-See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxclt-design.md) (private repo).
+See [design doc 024](https://github.com/itunified-io/infrastructure/blob/main/docs/plans/024-proxctl-design.md) (private repo).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/itunified-io/proxclt
+module github.com/itunified-io/proxctl
 
 go 1.25.0
 

--- a/internal/root/clientutil.go
+++ b/internal/root/clientutil.go
@@ -6,19 +6,19 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/itunified-io/proxclt/pkg/config"
-	"github.com/itunified-io/proxclt/pkg/proxmox"
+	"github.com/itunified-io/proxctl/pkg/config"
+	"github.com/itunified-io/proxctl/pkg/proxmox"
 	"gopkg.in/yaml.v3"
 )
 
-// proxcltConfig is the minimal on-disk config at ~/.proxclt/config.yaml.
+// proxctlConfig is the minimal on-disk config at ~/.proxctl/config.yaml.
 // (kubectl-style contexts — Phase 2 uses only a single current context.)
-type proxcltConfig struct {
+type proxctlConfig struct {
 	CurrentContext string           `yaml:"current-context"`
-	Contexts       []proxcltContext `yaml:"contexts"`
+	Contexts       []proxctlContext `yaml:"contexts"`
 }
 
-type proxcltContext struct {
+type proxctlContext struct {
 	Name        string `yaml:"name"`
 	Endpoint    string `yaml:"endpoint"`
 	TokenID     string `yaml:"token_id"`
@@ -26,20 +26,20 @@ type proxcltContext struct {
 	InsecureTLS bool   `yaml:"insecure_tls"`
 }
 
-// loadProxmoxClient loads credentials from ~/.proxclt/config.yaml (if present)
-// or from env vars PROXCLT_ENDPOINT / PROXCLT_TOKEN_ID / PROXCLT_TOKEN_SECRET.
+// loadProxmoxClient loads credentials from ~/.proxctl/config.yaml (if present)
+// or from env vars PROXCTL_ENDPOINT / PROXCTL_TOKEN_ID / PROXCTL_TOKEN_SECRET.
 func loadProxmoxClient() (*proxmox.Client, error) {
 	var (
-		endpoint    = os.Getenv("PROXCLT_ENDPOINT")
-		tokenID     = os.Getenv("PROXCLT_TOKEN_ID")
-		tokenSecret = os.Getenv("PROXCLT_TOKEN_SECRET")
-		insecure    = os.Getenv("PROXCLT_INSECURE_TLS") == "1"
+		endpoint    = os.Getenv("PROXCTL_ENDPOINT")
+		tokenID     = os.Getenv("PROXCTL_TOKEN_ID")
+		tokenSecret = os.Getenv("PROXCTL_TOKEN_SECRET")
+		insecure    = os.Getenv("PROXCTL_INSECURE_TLS") == "1"
 	)
 
 	home, _ := os.UserHomeDir()
-	cfgPath := filepath.Join(home, ".proxclt", "config.yaml")
+	cfgPath := filepath.Join(home, ".proxctl", "config.yaml")
 	if data, err := os.ReadFile(cfgPath); err == nil {
-		var cfg proxcltConfig
+		var cfg proxctlConfig
 		if err := yaml.Unmarshal(data, &cfg); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", cfgPath, err)
 		}
@@ -65,7 +65,7 @@ func loadProxmoxClient() (*proxmox.Client, error) {
 	}
 
 	if endpoint == "" || tokenID == "" || tokenSecret == "" {
-		return nil, errors.New("proxmox credentials missing: set $PROXCLT_ENDPOINT/$PROXCLT_TOKEN_ID/$PROXCLT_TOKEN_SECRET or create ~/.proxclt/config.yaml")
+		return nil, errors.New("proxmox credentials missing: set $PROXCTL_ENDPOINT/$PROXCTL_TOKEN_ID/$PROXCTL_TOKEN_SECRET or create ~/.proxctl/config.yaml")
 	}
 	return proxmox.NewClient(proxmox.ClientOpts{
 		Endpoint:    endpoint,

--- a/internal/root/config.go
+++ b/internal/root/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/itunified-io/proxclt/pkg/config"
+	"github.com/itunified-io/proxctl/pkg/config"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -12,7 +12,7 @@ import (
 func newConfigCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "config",
-		Short: "Manage proxclt contexts and env manifests",
+		Short: "Manage proxctl contexts and env manifests",
 	}
 
 	validateCmd := &cobra.Command{

--- a/internal/root/env.go
+++ b/internal/root/env.go
@@ -5,7 +5,7 @@ import "github.com/spf13/cobra"
 func newEnvCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "env",
-		Short: "Manage env bookmarks (~/.proxclt/envs.yaml)",
+		Short: "Manage env bookmarks (~/.proxctl/envs.yaml)",
 	}
 	c.AddCommand(
 		&cobra.Command{Use: "new NAME", Short: "Scaffold a new env directory", Args: cobra.ExactArgs(1), RunE: notImplemented("env new")},

--- a/internal/root/kickstart.go
+++ b/internal/root/kickstart.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/itunified-io/proxclt/pkg/kickstart"
+	"github.com/itunified-io/proxctl/pkg/kickstart"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/root/license.go
+++ b/internal/root/license.go
@@ -5,7 +5,7 @@ import "github.com/spf13/cobra"
 func newLicenseCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "license",
-		Short: "Inspect + activate proxclt license (~/.proxclt/license.jwt)",
+		Short: "Inspect + activate proxctl license (~/.proxctl/license.jwt)",
 	}
 	c.AddCommand(
 		&cobra.Command{Use: "status", Short: "Current tier, expiry, seats", RunE: notImplemented("license status")},

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -1,4 +1,4 @@
-// Package root wires all proxclt subcommands into a single Cobra tree.
+// Package root wires all proxctl subcommands into a single Cobra tree.
 package root
 
 import (
@@ -19,15 +19,15 @@ var (
 // New returns a fully configured root command.
 func New() *cobra.Command {
 	root := &cobra.Command{
-		Use:   "proxclt",
+		Use:   "proxctl",
 		Short: "Proxmox VM provisioning CLI — kickstart, lifecycle, workflows",
-		Long: `proxclt is a standalone Go binary for Proxmox VM provisioning.
+		Long: `proxctl is a standalone Go binary for Proxmox VM provisioning.
 
 See docs/ for the full user guide, configuration reference, and licensing model.`,
 		SilenceUsage: true,
 	}
 
-	root.PersistentFlags().StringVar(&flagContext, "context", "", "proxclt context to use (overrides current-context)")
+	root.PersistentFlags().StringVar(&flagContext, "context", "", "proxctl context to use (overrides current-context)")
 	root.PersistentFlags().StringVar(&flagEnv, "env", "", "env manifest name or path (overrides current env)")
 	root.PersistentFlags().BoolVar(&flagJSON, "json", false, "emit JSON on stdout (stderr still carries logs)")
 	root.PersistentFlags().BoolVarP(&flagYes, "yes", "y", false, "assume yes for confirm prompts (DANGEROUS)")

--- a/internal/root/root_test.go
+++ b/internal/root/root_test.go
@@ -32,7 +32,7 @@ func TestVersionCmd_Runs(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("version returned error: %v", err)
 	}
-	if !strings.Contains(buf.String(), "proxclt") {
-		t.Errorf("version output missing 'proxclt': %q", buf.String())
+	if !strings.Contains(buf.String(), "proxctl") {
+		t.Errorf("version output missing 'proxctl': %q", buf.String())
 	}
 }

--- a/internal/root/version.go
+++ b/internal/root/version.go
@@ -5,15 +5,15 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/itunified-io/proxclt/pkg/version"
+	"github.com/itunified-io/proxctl/pkg/version"
 )
 
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
-		Short: "Print proxclt version, commit, and build date",
+		Short: "Print proxctl version, commit, and build date",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			fmt.Fprintf(cmd.OutOrStdout(), "proxclt %s (commit %s, built %s)\n",
+			fmt.Fprintf(cmd.OutOrStdout(), "proxctl %s (commit %s, built %s)\n",
 				version.Version, version.Commit, version.Date)
 			return nil
 		},

--- a/internal/root/vm.go
+++ b/internal/root/vm.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/itunified-io/proxclt/pkg/kickstart"
-	"github.com/itunified-io/proxclt/pkg/proxmox"
-	"github.com/itunified-io/proxclt/pkg/workflow"
+	"github.com/itunified-io/proxctl/pkg/kickstart"
+	"github.com/itunified-io/proxctl/pkg/proxmox"
+	"github.com/itunified-io/proxctl/pkg/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/root/workflow.go
+++ b/internal/root/workflow.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/itunified-io/proxclt/pkg/kickstart"
-	"github.com/itunified-io/proxclt/pkg/workflow"
+	"github.com/itunified-io/proxctl/pkg/kickstart"
+	"github.com/itunified-io/proxctl/pkg/workflow"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/testutil/doc.go
+++ b/internal/testutil/doc.go
@@ -1,3 +1,3 @@
-// Package testutil holds shared test fixtures + helpers for proxclt.
+// Package testutil holds shared test fixtures + helpers for proxctl.
 // Phase 1 scaffold: placeholder.
 package testutil

--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Database is a fully opaque manifest; proxclt does not act on it.
+// Database is a fully opaque manifest; proxctl does not act on it.
 type Database struct {
 	Kind string         `yaml:"kind" json:"kind" validate:"required,oneof=OracleDatabase PostgresDatabase"`
 	Raw  map[string]any `yaml:"-"    json:"raw,omitempty"`

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -1,4 +1,4 @@
-// Package config defines the proxclt env manifest model, YAML loader,
+// Package config defines the proxctl env manifest model, YAML loader,
 // $ref resolution, profile inheritance, secret placeholder resolution,
 // cross-field validation, and JSON Schema export.
 package config

--- a/pkg/config/hooks.go
+++ b/pkg/config/hooks.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Hooks is the set of lifecycle hooks that can fire during proxclt operations.
+// Hooks is the set of lifecycle hooks that can fire during proxctl operations.
 type Hooks struct {
 	OnValidateSuccess []Hook `yaml:"on_validate_success,omitempty" json:"on_validate_success,omitempty" validate:"dive"`
 	OnApplyStart      []Hook `yaml:"on_apply_start,omitempty"      json:"on_apply_start,omitempty"      validate:"dive"`

--- a/pkg/config/hypervisor.go
+++ b/pkg/config/hypervisor.go
@@ -1,7 +1,7 @@
 package config
 
 // Hypervisor describes the Proxmox-side topology (nodes, VMIDs, disks, NICs,
-// ISO/kickstart bits). Owned by proxclt.
+// ISO/kickstart bits). Owned by proxctl.
 type Hypervisor struct {
 	Kind      string           `yaml:"kind"                 json:"kind"                 validate:"required,eq=Hypervisor"`
 	Nodes     map[string]Node  `yaml:"nodes"                json:"nodes"                validate:"required,min=1,dive"`
@@ -79,7 +79,7 @@ type ISOConfig struct {
 	BootloaderDir    string `yaml:"bootloader_dir,omitempty"   json:"bootloader_dir,omitempty"`
 }
 
-// KickstartConfig is the per-env kickstart/preseed inputs proxclt renders into a bootstrap file.
+// KickstartConfig is the per-env kickstart/preseed inputs proxctl renders into a bootstrap file.
 type KickstartConfig struct {
 	Distro          string              `yaml:"distro"                     json:"distro"                     validate:"required,oneof=oraclelinux8 oraclelinux9 ubuntu2204 rhel9 rocky9 sles15"`
 	Timezone        string              `yaml:"timezone,omitempty"         json:"timezone,omitempty"`

--- a/pkg/config/linux.go
+++ b/pkg/config/linux.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Linux is the linux.yaml passthrough manifest. proxclt reads this for
+// Linux is the linux.yaml passthrough manifest. proxctl reads this for
 // cross-file validation (disk tag refs) but otherwise treats it as opaque.
 type Linux struct {
 	Kind string         `yaml:"kind" json:"kind" validate:"required,eq=Linux"`

--- a/pkg/kickstart/iso_builder.go
+++ b/pkg/kickstart/iso_builder.go
@@ -59,7 +59,7 @@ func (b *ISOBuilder) Build(kickstartContent, hostname string) (string, error) {
 	if workRoot == "" {
 		workRoot = os.TempDir()
 	}
-	buildDir, err := os.MkdirTemp(workRoot, "proxclt-iso-"+hostname+"-")
+	buildDir, err := os.MkdirTemp(workRoot, "proxctl-iso-"+hostname+"-")
 	if err != nil {
 		return "", fmt.Errorf("mkdtemp: %w", err)
 	}
@@ -89,7 +89,7 @@ LABEL linux
 	}
 
 	// Build the ISO.
-	outPath := filepath.Join(workRoot, fmt.Sprintf("proxclt-%s.iso", hostname))
+	outPath := filepath.Join(workRoot, fmt.Sprintf("proxctl-%s.iso", hostname))
 	// Remove any stale output.
 	_ = os.Remove(outPath)
 

--- a/pkg/kickstart/renderer.go
+++ b/pkg/kickstart/renderer.go
@@ -1,5 +1,5 @@
 // Package kickstart renders per-node kickstart/preseed files from the
-// proxclt env manifest and bundles them into bootable ISOs.
+// proxctl env manifest and bundles them into bootable ISOs.
 package kickstart
 
 import (
@@ -13,7 +13,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"github.com/itunified-io/proxclt/pkg/config"
+	"github.com/itunified-io/proxctl/pkg/config"
 )
 
 //go:embed templates/common/*.tmpl templates/*/*.tmpl

--- a/pkg/kickstart/renderer_test.go
+++ b/pkg/kickstart/renderer_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/itunified-io/proxclt/pkg/config"
+	"github.com/itunified-io/proxctl/pkg/config"
 )
 
 func buildEnv() *config.Env {
@@ -46,7 +46,7 @@ func buildEnv() *config.Env {
 			UpdateSystem:   true,
 			ChronyServers:  []string{"pool.ntp.org"},
 			SSHKeys: map[string][]string{
-				"root": {"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY test@proxclt"},
+				"root": {"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITESTKEY test@proxctl"},
 			},
 			Packages: &config.PackagesConfig{
 				Base: []string{"htop"},
@@ -54,7 +54,7 @@ func buildEnv() *config.Env {
 			},
 			Firewall: &config.KSFirewall{Enabled: true},
 			AdditionalUsers: []config.AdditionalUser{
-				{Name: "deploy", Wheel: true, SSHKey: "ssh-rsa AAAAB3DEPLOYKEY deploy@proxclt"},
+				{Name: "deploy", Wheel: true, SSHKey: "ssh-rsa AAAAB3DEPLOYKEY deploy@proxctl"},
 			},
 			Sudo: &config.SudoConfig{WheelNopasswd: true},
 		},

--- a/pkg/kickstart/templates/common/post.tmpl
+++ b/pkg/kickstart/templates/common/post.tmpl
@@ -1,11 +1,11 @@
 {{- define "post_common" -}}
 %post --erroronfail --log=/var/log/ks-post.log
-echo "proxclt post-install start: $(date)"
+echo "proxctl post-install start: $(date)"
 
 # Chrony servers
 {{- if .Kickstart.ChronyServers }}
 {
-  echo "# proxclt chrony servers"
+  echo "# proxctl chrony servers"
 {{- range $srv := .Kickstart.ChronyServers }}
   echo "server {{ $srv }} iburst"
 {{- end }}

--- a/pkg/kickstart/templates/oraclelinux8/base.ks.tmpl
+++ b/pkg/kickstart/templates/oraclelinux8/base.ks.tmpl
@@ -1,5 +1,5 @@
 #version=OL8
-# proxclt-generated kickstart for {{ .FQDN }}
+# proxctl-generated kickstart for {{ .FQDN }}
 # Distro: {{ .Kickstart.Distro }}
 
 {{ if eq .Kickstart.Mode "graphical" }}graphical{{ else }}text{{ end }}

--- a/pkg/kickstart/templates/oraclelinux9/base.ks.tmpl
+++ b/pkg/kickstart/templates/oraclelinux9/base.ks.tmpl
@@ -1,5 +1,5 @@
 #version=OL9
-# proxclt-generated kickstart for {{ .FQDN }}
+# proxctl-generated kickstart for {{ .FQDN }}
 # Distro: {{ .Kickstart.Distro }}
 
 # Installation mode

--- a/pkg/kickstart/templates/ubuntu2204/preseed.cfg.tmpl
+++ b/pkg/kickstart/templates/ubuntu2204/preseed.cfg.tmpl
@@ -1,4 +1,4 @@
-# proxclt-generated preseed for {{ .FQDN }}
+# proxctl-generated preseed for {{ .FQDN }}
 # Distro: {{ .Kickstart.Distro }}
 
 d-i debian-installer/locale string {{ if .Kickstart.Lang }}{{ .Kickstart.Lang }}{{ else }}en_US.UTF-8{{ end }}

--- a/pkg/license/gate.go
+++ b/pkg/license/gate.go
@@ -1,10 +1,10 @@
-// Package license wraps dbx/pkg/core/license for proxclt's per-tool gate.
+// Package license wraps dbx/pkg/core/license for proxctl's per-tool gate.
 //
 // Phase 1 (scaffold): thin stub with ToolTier constants + ToolCatalog map.
 // Phase 2+ will wire Check() through to github.com/itunified-io/dbx/pkg/core/license.
 package license
 
-// ToolTier classifies each proxclt leaf command against a commercial tier.
+// ToolTier classifies each proxctl leaf command against a commercial tier.
 type ToolTier int
 
 const (
@@ -30,7 +30,7 @@ func (t ToolTier) String() string {
 	}
 }
 
-// ToolCatalog maps each proxclt leaf command to its required tier.
+// ToolCatalog maps each proxctl leaf command to its required tier.
 // Authoritative source for the license gate — see docs/licensing.md.
 var ToolCatalog = map[string]ToolTier{
 	// config group

--- a/pkg/state/db.go
+++ b/pkg/state/db.go
@@ -1,4 +1,4 @@
-// Package state provides the SQLite-backed persistence layer for proxclt.
+// Package state provides the SQLite-backed persistence layer for proxctl.
 //
 // Phase 1 (scaffold): types + stubs. Real implementation lands in Phase 2
 // with modernc.org/sqlite (pure Go, no CGO) per design doc §4.5.
@@ -12,7 +12,7 @@ import (
 // ErrNotImplemented is returned by stubbed methods during scaffold phase.
 var ErrNotImplemented = errors.New("state: not implemented yet (scaffold)")
 
-// DB is the handle for the proxclt state database (~/.proxclt/state.db).
+// DB is the handle for the proxctl state database (~/.proxctl/state.db).
 type DB struct {
 	path string
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
-// Package version exposes the baked-in build metadata for proxclt.
+// Package version exposes the baked-in build metadata for proxctl.
 // Values are injected via -ldflags at build time (see .goreleaser.yaml).
 package version
 

--- a/pkg/workflow/single_vm.go
+++ b/pkg/workflow/single_vm.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/itunified-io/proxclt/pkg/config"
-	"github.com/itunified-io/proxclt/pkg/kickstart"
-	"github.com/itunified-io/proxclt/pkg/proxmox"
+	"github.com/itunified-io/proxctl/pkg/config"
+	"github.com/itunified-io/proxctl/pkg/kickstart"
+	"github.com/itunified-io/proxctl/pkg/proxmox"
 )
 
 // Change is a single unit of work in the plan.
@@ -158,7 +158,7 @@ func (w *SingleVMWorkflow) Apply(ctx context.Context, changes []Change) error {
 			if isoPath == "" {
 				return errors.New("apply: iso path empty (did build-iso run?)")
 			}
-			if err := w.Client.UploadISO(ctx, r.node.Proxmox.NodeName, r.iso.KickstartStorage, isoPath, fmt.Sprintf("proxclt-%s.iso", w.NodeName)); err != nil {
+			if err := w.Client.UploadISO(ctx, r.node.Proxmox.NodeName, r.iso.KickstartStorage, isoPath, fmt.Sprintf("proxctl-%s.iso", w.NodeName)); err != nil {
 				return fmt.Errorf("upload-iso: %w", err)
 			}
 		case "create-vm":

--- a/pkg/workflow/single_vm_test.go
+++ b/pkg/workflow/single_vm_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/itunified-io/proxclt/pkg/config"
-	"github.com/itunified-io/proxclt/pkg/kickstart"
-	"github.com/itunified-io/proxclt/pkg/proxmox"
+	"github.com/itunified-io/proxctl/pkg/config"
+	"github.com/itunified-io/proxctl/pkg/kickstart"
+	"github.com/itunified-io/proxctl/pkg/proxmox"
 )
 
 func testEnv() *config.Env {


### PR DESCRIPTION
## Summary

Rename of the tool from `proxclt` → `proxctl` (BREAKING) following the GitHub repo rename.

- Go module path: `github.com/itunified-io/proxctl`
- Binary: `proxctl` (directory `cmd/proxctl/`)
- Config/state dir: `~/.proxctl/`
- Env vars: `PROXCTL_*`
- Docs, README, Makefile, Dockerfile, .goreleaser.yaml, CI workflow updated
- CHANGELOG v2026.04.11.3 entry at top

## Verification

- `go build ./...` — OK
- `go test ./...` — all packages pass
- `go vet ./...` — clean
- `proxctl --help` smoke test — help text + subcommands correct

## What was NOT changed

- Historical commit messages / CHANGELOG entries below v2026.04.11.3 (tag `v2026.04.11.2` preserved)
- infrastructure/docs/ (separate repo)