### PR TITLE
fix: accept 'host-only' cluster type

### DIFF
--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -3,7 +3,7 @@ package config
 // Cluster describes optional cluster-level semantics (RAC, PG HA, etc.).
 type Cluster struct {
 	Kind               string      `yaml:"kind"                           json:"kind"                           validate:"required,eq=Cluster"`
-	Type               string      `yaml:"type,omitempty"                 json:"type,omitempty"                 validate:"omitempty,oneof=oracle-rac oracle-single pg-single pg-ha plain"`
+	Type               string      `yaml:"type,omitempty"                 json:"type,omitempty"                 validate:"omitempty,oneof=oracle-rac oracle-single pg-single pg-ha plain host-only"`
 	ScanName           string      `yaml:"scan_name,omitempty"            json:"scan_name,omitempty"`
 	ScanIPs            []string    `yaml:"scan_ips,omitempty"             json:"scan_ips,omitempty"             validate:"omitempty,dive,ip"`
 	InterconnectSubnet string      `yaml:"interconnect_subnet,omitempty"  json:"interconnect_subnet,omitempty"  validate:"omitempty,cidr"`


### PR DESCRIPTION
host-only profile ships with cluster.type=host-only but validator oneof rejected it. Ref proxctl#10 finding.