### PR TITLE
fix: kickstart/vm/workflow/boot resolve $ref envs (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.28.1 — 2026-04-28
+
+### fix: kickstart/vm/workflow/boot subcommands resolve $ref envs (#19)
+
+`internal/root/clientutil.go:loadEnvManifest()` did a raw `yaml.Unmarshal`
+with no `$ref` resolution. Subcommands using it (`kickstart generate`,
+`vm list/get/create/start/stop/delete`, `boot ...`, `workflow ...`) failed
+with `Error: hypervisor not resolved` on any env manifest that composes via
+`$ref` — the canonical pattern in `infrastructure/stacks/<stack>/env.yaml`.
+
+The same env manifest loaded cleanly via `proxctl config render` /
+`proxctl config validate`, both of which already routed through
+`config.Load`. Fix is one call site: route `loadEnvManifest` through
+`config.Load` so `$ref` pointers are resolved, profile extends are applied,
+and secret placeholders are expanded — same path config render uses.
+
+Tests updated: two `*_HypervisorNotResolved` tests previously locked-in the
+buggy behaviour; renamed + flipped to assert the fix
+(`TestVM_List_RefFixtureLoadsAndProceeds`,
+`TestKickstart_Generate_RefFixtureLoaderResolvesRefs`). Stale comment on
+`writeEnvFixture` updated.
+
+Closes #19. Caught while running plan-034 `/lab-up --phase A,B,C` for the
+ext3+ext4 Oracle DG lab.
+
 ## v2026.04.11.8 — 2026-04-22
 
 ### BREAKING — CLI verb rename `env` → `stack` (#15)

--- a/internal/root/clientutil.go
+++ b/internal/root/clientutil.go
@@ -79,6 +79,13 @@ func loadProxmoxClient() (*proxmox.Client, error) {
 // (the --stack path; the deprecated --env flag is folded into flagStack by
 // resolveDeprecatedFlags), then at ./env.yaml.
 //
+// Routes through config.Load so $ref pointers are resolved, profile extends are
+// applied, and secret placeholders are expanded — the same path
+// `proxctl config render` uses. Without this, callers' subsequent calls to
+// `env.Spec.Hypervisor.Resolved()` return nil with "hypervisor not resolved"
+// on any manifest that composes via $ref (the canonical pattern in
+// infrastructure/stacks/<stack>/env.yaml). See #19.
+//
 // NOTE: the on-disk filename stays `env.yaml` and the Go type stays
 // `config.Env`. Only the CLI verb/flag changed in #15. See CHANGELOG
 // v2026.04.11.8.
@@ -90,15 +97,14 @@ func loadEnvManifest(explicitPath string) (*config.Env, error) {
 	if path == "" {
 		path = "env.yaml"
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
+	if _, err := os.Stat(path); err != nil {
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
-	var env config.Env
-	if err := yaml.Unmarshal(data, &env); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", path, err)
+	env, err := config.Load(path)
+	if err != nil {
+		return nil, fmt.Errorf("load %s: %w", path, err)
 	}
-	return &env, nil
+	return env, nil
 }
 
 // resolveNodeRef pulls the ProxmoxRef (node name + vmid) for the given node name.

--- a/internal/root/coverage_test.go
+++ b/internal/root/coverage_test.go
@@ -53,9 +53,10 @@ func isolateHome(t *testing.T) string {
 	return home
 }
 
-// writeEnvFixture writes an inline env.yaml into dir. An inline manifest is used
-// because loadEnvManifest() in clientutil.go does a raw yaml.Unmarshal (no $ref
-// resolution), so fixtures must set Hypervisor.Inline directly.
+// writeEnvFixture writes an inline env.yaml into dir. Both inline and $ref-
+// composed manifests are supported by loadEnvManifest (which now routes through
+// config.Load — see #19); this helper covers the inline path. For $ref tests,
+// use writeRefEnvFixture.
 func writeEnvFixture(t *testing.T, dir string) string {
 	t.Helper()
 	// Also copy the $ref-style fixture used by config validate/render tests.
@@ -549,15 +550,16 @@ func TestVM_Status_UnknownNode2(t *testing.T) {
 	}
 }
 
-func TestVM_List_HypervisorNotResolved(t *testing.T) {
-	// $ref fixture triggers "hypervisor not resolved" branch in vm list.
+func TestVM_List_RefFixtureLoadsAndProceeds(t *testing.T) {
+	// Post-#19: loadEnvManifest now routes through config.Load which resolves
+	// $ref pointers, so vm list against a $ref-composed env succeeds (does not
+	// produce "hypervisor not resolved" anymore).
 	home := isolateHome(t)
 	writeRefEnvFixture(t, home)
 	t.Chdir(home)
-	startProxmox(t, func(w http.ResponseWriter, r *http.Request) { writeJSON(w, nil) })
-	_, err := executeCmd(t, "vm", "list")
-	if err == nil || !strings.Contains(err.Error(), "hypervisor not resolved") {
-		t.Errorf("expected hypervisor error, got %v", err)
+	startProxmox(t, func(w http.ResponseWriter, r *http.Request) { writeJSON(w, []map[string]any{}) })
+	if _, err := executeCmd(t, "vm", "list"); err != nil {
+		t.Fatalf("vm list against $ref env: %v", err)
 	}
 }
 
@@ -1078,15 +1080,19 @@ func TestKickstart_Generate_SingleNode(t *testing.T) {
 	}
 }
 
-func TestKickstart_Generate_HypervisorNotResolved(t *testing.T) {
-	// Use the $ref-style fixture: loadEnvManifest does raw yaml.Unmarshal with
-	// no $ref resolution, so Hypervisor.Resolved() returns nil.
+func TestKickstart_Generate_RefFixtureLoaderResolvesRefs(t *testing.T) {
+	// Post-#19: loadEnvManifest now routes through config.Load which resolves
+	// $ref pointers. This test asserts the loader-level fix: kickstart generate
+	// against a $ref-composed env no longer fails with "hypervisor not resolved".
+	// Downstream errors (e.g. the shared testdata fixture has no kickstart distro
+	// set, so the renderer reports "env has no kickstart config") are acceptable
+	// here — they prove we got past the loader gate.
 	home := isolateHome(t)
 	writeRefEnvFixture(t, home)
 	t.Chdir(home)
 	_, err := executeCmd(t, "kickstart", "generate", "--out", filepath.Join(home, "out-ref"))
-	if err == nil || !strings.Contains(err.Error(), "hypervisor not resolved") {
-		t.Errorf("expected 'hypervisor not resolved', got %v", err)
+	if err != nil && strings.Contains(err.Error(), "hypervisor not resolved") {
+		t.Fatalf("loadEnvManifest still not resolving $refs: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`loadEnvManifest()` did raw `yaml.Unmarshal` with no $ref resolution — every command using it failed with "hypervisor not resolved" on the canonical $ref-composed env manifests in `infrastructure/stacks/<stack>/env.yaml`. `config render` worked because it routed through `config.Load`. This PR routes `loadEnvManifest` through `config.Load` too. One-call-site fix.

Tests: two `*_HypervisorNotResolved` tests previously locked in the buggy behaviour; renamed + flipped. Stale comment on `writeEnvFixture` updated. Full test suite green.

## Test plan

- [x] go build ./...
- [x] go test ./... (all green)
- [ ] Live verification: `proxctl kickstart generate stacks/ext3/env.yaml -o /tmp/ks` produces .ks files (gated on stack having a kickstart distro section — orthogonal stacks-side gap)

Closes #19