### PR TITLE
fix: isNotFound recognizes Proxmox 500+null pattern (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.28.2 — 2026-04-28
+
+### fix: isNotFound recognizes Proxmox's 500+null pattern (#21)
+
+`pkg/proxmox/vm.go:isNotFound` didn't recognize a Proxmox quirk: missing
+`/nodes/<n>/qemu/<vmid>/status/current` returns HTTP 500 with body
+`{"data":null}` instead of 404. As a result, `VMExists` surfaced a generic
+500 error and the `workflow up` (and `vm create / start / stop / delete`)
+preconditions failed for any fresh VMID:
+
+```
+Error: plan: vm-exists check: proxmox api error: status=500 message="{"data":null}"
+```
+
+Fix: when the APIError has StatusCode 500, no Errors map, and Message is
+exactly `{"data":null}` (whitespace tolerated), treat it as not-found.
+Other 500s (real errors) keep their semantic. Tests in
+`pkg/proxmox/coverage_test.go::TestIsNotFound_500NullData` cover the new
+branch + a few false-positive guards.
+
+Caught while running `/lab-up --phase B` for ext3+ext4 in
+itunified-io/infrastructure (plan 034) immediately after v2026.04.28.1
+unblocked the loadEnvManifest path.
+
+Closes #21.
+
 ## v2026.04.28.1 — 2026-04-28
 
 ### fix: kickstart/vm/workflow/boot subcommands resolve $ref envs (#19)

--- a/pkg/proxmox/coverage_test.go
+++ b/pkg/proxmox/coverage_test.go
@@ -515,6 +515,20 @@ func TestIsNotFound_ErrorsMap(t *testing.T) {
 	assert.False(t, isNotFound(&APIError{StatusCode: 500, Errors: map[string]string{"k": "ok"}}))
 }
 
+func TestIsNotFound_500NullData(t *testing.T) {
+	// Proxmox quirk: GET /nodes/<n>/qemu/<missing-vmid>/status/current returns
+	// HTTP 500 with body `{"data":null}` instead of 404. parseAPIError stuffs
+	// the raw body into Message when both Errors and Message are empty, so
+	// we must recognize that exact pattern.
+	assert.True(t, isNotFound(&APIError{StatusCode: 500, Message: `{"data":null}`}))
+	assert.True(t, isNotFound(&APIError{StatusCode: 500, Message: `  {"data":null}  `})) // tolerate whitespace
+	// Don't false-positive on a 500 with a real message body.
+	assert.False(t, isNotFound(&APIError{StatusCode: 500, Message: `{"data":{"vmid":9}}`}))
+	assert.False(t, isNotFound(&APIError{StatusCode: 500, Message: `internal error`}))
+	// Don't conflate with 200 + null (success/no-op).
+	assert.False(t, isNotFound(&APIError{StatusCode: 200, Message: `{"data":null}`}))
+}
+
 // --- Boot: ConfigureFirstBoot failure paths ------------------------------
 
 func TestConfigureFirstBoot_AttachIDE2Fails(t *testing.T) {

--- a/pkg/proxmox/vm.go
+++ b/pkg/proxmox/vm.go
@@ -380,6 +380,12 @@ func splitTags(s string) []string {
 }
 
 // isNotFound returns true if the error indicates a 404/500 "does not exist".
+//
+// Proxmox is inconsistent: missing VMs/tasks/storage paths come back as a 404
+// with a clear message in some endpoints, but `/nodes/<n>/qemu/<id>/status/current`
+// returns HTTP 500 with body `{"data":null}` instead. We recognize both
+// patterns so VMExists can correctly report `false` for absent IDs (and
+// callers like the workflow vm-exists precondition treat it as "id is free").
 func isNotFound(err error) bool {
 	apiErr, ok := err.(*APIError)
 	if !ok {
@@ -395,6 +401,15 @@ func isNotFound(err error) bool {
 	for _, v := range apiErr.Errors {
 		lv := strings.ToLower(v)
 		if strings.Contains(lv, "does not exist") || strings.Contains(lv, "no such") {
+			return true
+		}
+	}
+	// Proxmox-quirk fallback: 500 + body `{"data":null}` (no errors field, no
+	// message field). parseAPIError stuffs the raw body into Message when both
+	// Errors and Message are empty, so the pattern surfaces here.
+	if apiErr.StatusCode == http.StatusInternalServerError && len(apiErr.Errors) == 0 {
+		trimmed := strings.TrimSpace(apiErr.Message)
+		if trimmed == `{"data":null}` {
 			return true
 		}
 	}


### PR DESCRIPTION
Proxmox returns 500 + `{"data":null}` when a VMID doesn't exist. `isNotFound` only recognized 404 + message-substring patterns. Adds the 500+null branch with tests. Closes #21.