### PR TITLE
feat: --skip-kickstart-build flag (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.28.3 — 2026-04-28
+
+### feat: --skip-kickstart-build flag (#23)
+
+Adds `--skip-kickstart-build` to `workflow plan/up` and `vm create`. When
+set, the workflow drops the `render-kickstart`, `build-iso`, and
+`upload-iso` steps (which require a bootloader-dir + xorriso) and instead
+runs:
+
+1. `verify-kickstart-iso` — checks `<kickstart_storage>:iso/<node>_kickstart.iso` is present
+2. `create-vm`
+3. `start-vm`
+
+Use this when the operator built and uploaded the kickstart ISO out-of-band
+(e.g. an OEMDRV-labeled ISO that Anaconda auto-discovers, or a kickstart ISO
+maintained by a separate pipeline). Avoids the bootloader-dir requirement for
+operators who don't need the proxctl-built remastered install ISO.
+
+Implementation:
+- `SingleVMWorkflow.SkipKickstartBuild bool` (and `MultiNodeWorkflow.SkipKickstartBuild`)
+- New `Client.StorageContentExists(ctx, node, storage, volid)` for the verify step
+- New apply branch `verify-kickstart-iso`
+- Plan output reflects the slimmer change set
+- Tests in `pkg/workflow/single_vm_test.go::TestPlan_SkipKickstartBuild`
+
+Caught while running `/lab-up --phase B` for ext3+ext4 in
+itunified-io/infrastructure (plan 034) — the third gate after
+v2026.04.28.1 (#19) and v2026.04.28.2 (#21).
+
+Closes #23.
+
 ## v2026.04.28.2 — 2026-04-28
 
 ### fix: isNotFound recognizes Proxmox's 500+null pattern (#21)

--- a/internal/root/vm.go
+++ b/internal/root/vm.go
@@ -23,32 +23,40 @@ func newVMCmd() *cobra.Command {
 	var vmDeletePurge bool
 
 	c.AddCommand(
-		&cobra.Command{
-			Use:   "create NAME",
-			Short: "Create a VM from env spec",
-			Args:  cobra.ExactArgs(1),
-			RunE: func(cmd *cobra.Command, args []string) error {
-				env, err := loadEnvManifest("")
-				if err != nil {
-					return err
-				}
-				client, err := loadProxmoxClient()
-				if err != nil {
-					return err
-				}
-				rnd, err := kickstart.NewRenderer()
-				if err != nil {
-					return err
-				}
-				w := &workflow.SingleVMWorkflow{
-					Config:   env,
-					NodeName: args[0],
-					Client:   client,
-					Renderer: rnd,
-				}
-				return w.Up(context.Background())
-			},
-		},
+		func() *cobra.Command {
+			var skipKickstart bool
+			cc := &cobra.Command{
+				Use:   "create NAME",
+				Short: "Create a VM from env spec",
+				Args:  cobra.ExactArgs(1),
+				RunE: func(cmd *cobra.Command, args []string) error {
+					env, err := loadEnvManifest("")
+					if err != nil {
+						return err
+					}
+					client, err := loadProxmoxClient()
+					if err != nil {
+						return err
+					}
+					rnd, err := kickstart.NewRenderer()
+					if err != nil {
+						return err
+					}
+					w := &workflow.SingleVMWorkflow{
+						Config:             env,
+						NodeName:           args[0],
+						Client:             client,
+						Renderer:           rnd,
+						SkipKickstartBuild: skipKickstart,
+					}
+					return w.Up(context.Background())
+				},
+			}
+			cc.Flags().BoolVar(&skipKickstart, "skip-kickstart-build", false,
+				"skip render/build/upload of kickstart ISO; assume operator pre-uploaded "+
+					"<kickstart_storage>:iso/<NAME>_kickstart.iso (verified at apply time)")
+			return cc
+		}(),
 		&cobra.Command{
 			Use:   "start NAME",
 			Short: "Start a VM",

--- a/internal/root/workflow.go
+++ b/internal/root/workflow.go
@@ -36,6 +36,7 @@ func newWorkflowCmd() *cobra.Command {
 	var wfDryRun bool
 	var wfMaxConc int
 	var wfContinue bool
+	var wfSkipKickstart bool
 
 	loadCommon := func() (*config.Env, *kickstart.Renderer, *kickstart.ISOBuilder, error) {
 		env, err := loadEnvManifest("")
@@ -59,12 +60,13 @@ func newWorkflowCmd() *cobra.Command {
 			return nil, err
 		}
 		return &workflow.SingleVMWorkflow{
-			Config:   env,
-			NodeName: nodeName,
-			Client:   client,
-			Renderer: rnd,
-			Builder:  builder,
-			DryRun:   wfDryRun,
+			Config:             env,
+			NodeName:           nodeName,
+			Client:             client,
+			Renderer:           rnd,
+			Builder:            builder,
+			DryRun:             wfDryRun,
+			SkipKickstartBuild: wfSkipKickstart,
 		}, nil
 	}
 
@@ -79,6 +81,7 @@ func newWorkflowCmd() *cobra.Command {
 			m.MaxConcurrency = wfMaxConc
 		}
 		m.ContinueOnError = wfContinue
+		m.SkipKickstartBuild = wfSkipKickstart
 		return m, nil
 	}
 
@@ -263,6 +266,11 @@ func newWorkflowCmd() *cobra.Command {
 	for _, sub := range []*cobra.Command{planCmd, upCmd, downCmd, verifyCmd} {
 		sub.Flags().StringVar(&wfNode, "node", "", "node name from env manifest (single-node override)")
 		sub.Flags().StringVar(&wfBootloader, "bootloader-dir", "", "path to bootloader files (isolinux.bin, vmlinuz, initrd.img)")
+	}
+	for _, sub := range []*cobra.Command{planCmd, upCmd} {
+		sub.Flags().BoolVar(&wfSkipKickstart, "skip-kickstart-build", false,
+			"skip render/build/upload of kickstart ISO; assume operator pre-uploaded "+
+				"<kickstart_storage>:iso/<node>_kickstart.iso (verified at apply time)")
 	}
 	upCmd.Flags().BoolVar(&wfDryRun, "dry-run", false, "print actions without executing")
 	upCmd.Flags().IntVar(&wfMaxConc, "max-concurrency", 0, "cap concurrent per-node Apply goroutines (0=default)")

--- a/pkg/proxmox/storage.go
+++ b/pkg/proxmox/storage.go
@@ -45,6 +45,31 @@ func (c *Client) ListStorage(ctx context.Context, node string) ([]Storage, error
 	return out, nil
 }
 
+// StorageContentExists returns true if a volume with the given volid is present
+// in the storage's content listing. Used by workflow's `verify-kickstart-iso`
+// step (skip-kickstart-build mode) to assert the operator-uploaded ISO is in
+// place before VM create.
+//
+// volid is the Proxmox-style identifier `<storage>:<typedir>/<filename>`,
+// e.g. `proxmox:iso/ext3adm1_kickstart.iso`.
+func (c *Client) StorageContentExists(ctx context.Context, node, storage, volid string) (bool, error) {
+	var raws []struct {
+		VolID  string `json:"volid"`
+		Format string `json:"format"`
+		Size   int64  `json:"size"`
+	}
+	path := fmt.Sprintf("/nodes/%s/storage/%s/content", node, storage)
+	if err := c.Do(ctx, http.MethodGet, path, nil, &raws); err != nil {
+		return false, err
+	}
+	for _, r := range raws {
+		if r.VolID == volid {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // UploadISO uploads the file at localPath to the given storage as an ISO.
 // When remoteName is empty, the local file's basename is used.
 //

--- a/pkg/workflow/multi_node.go
+++ b/pkg/workflow/multi_node.go
@@ -36,6 +36,9 @@ type MultiNodeWorkflow struct {
 	// ISOUploadMu serializes ISO uploads across nodes. If nil, one is allocated
 	// internally.
 	ISOUploadMu *sync.Mutex
+	// SkipKickstartBuild propagates to every per-node SingleVMWorkflow. See
+	// SingleVMWorkflow.SkipKickstartBuild.
+	SkipKickstartBuild bool
 }
 
 // NewMultiNodeWorkflow is a small factory that fills sensible defaults.
@@ -80,13 +83,14 @@ func (m *MultiNodeWorkflow) nodeNames() ([]string, error) {
 // including the cross-node ISO-upload mutex.
 func (m *MultiNodeWorkflow) perNode(name string) *SingleVMWorkflow {
 	return &SingleVMWorkflow{
-		Config:   m.Config,
-		NodeName: name,
-		Client:   m.Client,
-		Renderer: m.Renderer,
-		Builder:  m.Builder,
-		DryRun:   m.DryRun,
-		UploadMu: m.isoMu(),
+		Config:             m.Config,
+		NodeName:           name,
+		Client:             m.Client,
+		Renderer:           m.Renderer,
+		Builder:            m.Builder,
+		DryRun:             m.DryRun,
+		UploadMu:           m.isoMu(),
+		SkipKickstartBuild: m.SkipKickstartBuild,
 	}
 }
 

--- a/pkg/workflow/single_vm.go
+++ b/pkg/workflow/single_vm.go
@@ -33,6 +33,14 @@ type SingleVMWorkflow struct {
 	// UploadMu serializes the upload-iso step across callers that share a
 	// Proxmox storage endpoint (multi-node Apply). Optional.
 	UploadMu *sync.Mutex
+	// SkipKickstartBuild — when true, the workflow skips the
+	// render-kickstart, build-iso, and upload-iso steps and goes straight
+	// to create-vm + start-vm. The kickstart ISO MUST already be present at
+	// `iso.kickstart_storage:<expected-volid>` (verified at plan time).
+	// Use this when the operator built and uploaded the kickstart ISO
+	// out-of-band (e.g. an OEMDRV-labeled ISO), or when iterating on VM
+	// hardware config without re-rendering kickstart. See #23.
+	SkipKickstartBuild bool
 }
 
 // resolved pulls commonly-accessed nested structures from the env.
@@ -89,19 +97,32 @@ func (w *SingleVMWorkflow) Plan(ctx context.Context) ([]Change, error) {
 		}
 	}
 
-	changes = append(changes,
-		Change{Kind: "render-kickstart", Target: w.NodeName,
-			Description: fmt.Sprintf("render %s kickstart for %s", safeDistro(r.ks), w.NodeName)},
-		Change{Kind: "build-iso", Target: w.NodeName,
-			Description: fmt.Sprintf("build kickstart ISO for %s", w.NodeName)},
-	)
+	if !w.SkipKickstartBuild {
+		changes = append(changes,
+			Change{Kind: "render-kickstart", Target: w.NodeName,
+				Description: fmt.Sprintf("render %s kickstart for %s", safeDistro(r.ks), w.NodeName)},
+			Change{Kind: "build-iso", Target: w.NodeName,
+				Description: fmt.Sprintf("build kickstart ISO for %s", w.NodeName)},
+		)
 
-	if r.iso != nil && r.iso.KickstartStorage != "" {
-		changes = append(changes, Change{
-			Kind:        "upload-iso",
-			Target:      r.iso.KickstartStorage,
-			Description: fmt.Sprintf("upload kickstart ISO to storage %s on node %s", r.iso.KickstartStorage, r.node.Proxmox.NodeName),
-		})
+		if r.iso != nil && r.iso.KickstartStorage != "" {
+			changes = append(changes, Change{
+				Kind:        "upload-iso",
+				Target:      r.iso.KickstartStorage,
+				Description: fmt.Sprintf("upload kickstart ISO to storage %s on node %s", r.iso.KickstartStorage, r.node.Proxmox.NodeName),
+			})
+		}
+	} else {
+		// Pre-condition: kickstart ISO must already be present on Proxmox storage.
+		// Surface in the plan so operators see what's being assumed; verified
+		// at apply time via Client.StorageContentExists if Client is available.
+		if r.iso != nil && r.iso.KickstartStorage != "" {
+			changes = append(changes, Change{
+				Kind:        "verify-kickstart-iso",
+				Target:      r.iso.KickstartStorage,
+				Description: fmt.Sprintf("verify kickstart ISO already uploaded to %s on node %s (skip-kickstart-build)", r.iso.KickstartStorage, r.node.Proxmox.NodeName),
+			})
+		}
 	}
 
 	changes = append(changes,
@@ -171,6 +192,21 @@ func (w *SingleVMWorkflow) Apply(ctx context.Context, changes []Change) error {
 			}
 			if err != nil {
 				return fmt.Errorf("upload-iso: %w", err)
+			}
+		case "verify-kickstart-iso":
+			if w.Client == nil {
+				return errors.New("apply: Client not set")
+			}
+			if r.iso == nil || r.iso.KickstartStorage == "" {
+				return errors.New("apply: iso.kickstart_storage not configured (cannot verify pre-uploaded kickstart ISO)")
+			}
+			expectedVolID := fmt.Sprintf("%s:iso/%s_kickstart.iso", r.iso.KickstartStorage, w.NodeName)
+			present, err := w.Client.StorageContentExists(ctx, r.node.Proxmox.NodeName, r.iso.KickstartStorage, expectedVolID)
+			if err != nil {
+				return fmt.Errorf("verify-kickstart-iso: %w", err)
+			}
+			if !present {
+				return fmt.Errorf("verify-kickstart-iso: %s not present on %s — upload it first or omit --skip-kickstart-build", expectedVolID, r.node.Proxmox.NodeName)
 			}
 		case "create-vm":
 			if w.Client == nil {

--- a/pkg/workflow/single_vm_test.go
+++ b/pkg/workflow/single_vm_test.go
@@ -102,6 +102,39 @@ func TestPlan(t *testing.T) {
 	}
 }
 
+func TestPlan_SkipKickstartBuild(t *testing.T) {
+	// With SkipKickstartBuild=true, the plan should drop render/build/upload
+	// and instead include a verify-kickstart-iso step, then create-vm + start-vm.
+	calls := []string{}
+	srv := mockPVE(t, &calls)
+	defer srv.Close()
+	client, err := proxmox.NewClient(proxmox.ClientOpts{
+		Endpoint: srv.URL, TokenID: "t@pve!k", TokenSecret: "secret",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := &SingleVMWorkflow{
+		Config:             testEnv(),
+		NodeName:           "web01",
+		Client:             client,
+		SkipKickstartBuild: true,
+	}
+	changes, err := w.Plan(context.Background())
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	wantKinds := []string{"verify-kickstart-iso", "create-vm", "start-vm"}
+	if len(changes) != len(wantKinds) {
+		t.Fatalf("want %d changes got %d: %+v", len(wantKinds), len(changes), changes)
+	}
+	for i, k := range wantKinds {
+		if changes[i].Kind != k {
+			t.Errorf("change[%d] kind: want %q got %q", i, k, changes[i].Kind)
+		}
+	}
+}
+
 func TestPlanDryRunApply(t *testing.T) {
 	calls := []string{}
 	srv := mockPVE(t, &calls)


### PR DESCRIPTION
Bypass render/build/upload-iso when operator pre-uploaded kickstart ISO. Adds verify-kickstart-iso step instead. Plumbed through workflow + vm create. Tests included. Closes #23.