### PR TITLE
fix: storage_class → backend resolution (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.28.4 — 2026-04-28
+
+### fix: buildCreateOpts resolves storage_class → backend (#25)
+
+`pkg/workflow/single_vm.go:buildCreateOpts` was passing the logical
+`Disk.StorageClass` name (e.g. `root`, `u01`, `asm`) straight into the
+Proxmox `scsi<N>=<storage>:<size>` form value, treating it as if it were a
+Proxmox storage backend. Result: HTTP 500 + `{"data":null}` from the create
+endpoint because Proxmox has no storage named "root".
+
+Fix: resolve `StorageClass` against `env.Spec.StorageClasses.Resolved()` to
+get the actual backend (`root → local-lvm`, `asm → nvme`, etc.). Propagate
+`StorageClass.Shared` to `DiskSpec.Shared`. EFIDisk uses the same resolver.
+Literal `Disk.Storage` (when set) still takes precedence — per-disk
+escape hatch.
+
+Tests in `pkg/workflow/single_vm_test.go`:
+- `TestBuildCreateOpts_OVMF_StorageClass` — flipped from asserting buggy
+  behavior to verifying resolution.
+- `TestBuildCreateOpts_StorageClass_PropagatesShared` — new.
+- `TestBuildCreateOpts_StorageClass_LiteralStorageWins` — new.
+
+Caught while running `/lab-up --phase B` for ext3+ext4 in
+itunified-io/infrastructure (plan 034) — fourth gate today after
+v2026.04.28.1 (#19), .2 (#21), .3 (#23).
+
+Closes #25.
+
 ## v2026.04.28.3 — 2026-04-28
 
 ### feat: --skip-kickstart-build flag (#23)

--- a/pkg/workflow/single_vm.go
+++ b/pkg/workflow/single_vm.go
@@ -312,14 +312,23 @@ func (w *SingleVMWorkflow) Down(ctx context.Context, force bool) error {
 }
 
 // buildCreateOpts maps the env Node into a proxmox.CreateOpts.
+//
+// Storage resolution: env Disk.StorageClass is a logical name (e.g. "root",
+// "u01", "asm") that must be resolved against the env's StorageClasses
+// catalogue (loaded from `_contexts/<ctx>/storage-classes.yaml`) to the
+// actual Proxmox backend (e.g. "local-lvm", "nvme"). Without resolution we
+// would POST e.g. `scsi0=root:64` to Proxmox and get HTTP 500. See #25.
+//
+// Disk.Storage (literal Proxmox storage name) takes precedence over
+// Disk.StorageClass when both are set, so per-stack overrides work.
 func buildCreateOpts(env *config.Env, nodeName string, node *config.Node, r *resolved) proxmox.CreateOpts {
 	opts := proxmox.CreateOpts{
-		Node:    node.Proxmox.NodeName,
-		VMID:    node.Proxmox.VMID,
-		Name:    nodeName,
-		Tags:    node.Tags,
-		OSType:  "l26",
-		SCSIHW:  "virtio-scsi-single",
+		Node:   node.Proxmox.NodeName,
+		VMID:   node.Proxmox.VMID,
+		Name:   nodeName,
+		Tags:   node.Tags,
+		OSType: "l26",
+		SCSIHW: "virtio-scsi-single",
 	}
 	if node.Resources != nil {
 		opts.Memory = node.Resources.Memory
@@ -329,24 +338,54 @@ func buildCreateOpts(env *config.Env, nodeName string, node *config.Node, r *res
 		opts.BIOS = node.Resources.BIOS
 		opts.Machine = node.Resources.Machine
 	}
+
+	// Resolve the StorageClasses catalogue once.
+	var sc *config.StorageClasses
+	if env != nil {
+		sc = env.Spec.StorageClasses.Resolved()
+	}
+
+	resolveStorage := func(d config.Disk) (backend string, shared bool) {
+		// Explicit literal storage wins (per-stack escape hatch).
+		if d.Storage != "" {
+			return d.Storage, d.Shared
+		}
+		// Map storage_class → backend via the catalogue.
+		if d.StorageClass != "" && sc != nil {
+			if cls, ok := sc.Classes[d.StorageClass]; ok {
+				return cls.Backend, cls.Shared || d.Shared
+			}
+		}
+		// Last-resort fallback so VM creation doesn't 500 on a missing class.
+		// validateDiskStorageRefs already caught unresolved classes during Load,
+		// so reaching this branch means env validation was bypassed somehow.
+		return "local-lvm", d.Shared
+	}
+
 	if strings.EqualFold(opts.BIOS, "ovmf") {
+		efiBackend := "local-lvm"
+		if len(node.Disks) > 0 {
+			b, _ := resolveStorage(node.Disks[0])
+			efiBackend = firstNonEmpty(b, "local-lvm")
+		}
 		opts.EFIDisk = &proxmox.EFIDiskSpec{
-			Storage:         firstNonEmpty(storageForDisk(node.Disks), "local-lvm"),
+			Storage:         efiBackend,
 			Format:          "raw",
 			PreEnrolledKeys: false,
 		}
 	}
-	// Disks: map config.Disk → proxmox.DiskSpec
+	// Disks: map config.Disk → proxmox.DiskSpec (with storage_class resolved).
 	for i, d := range node.Disks {
 		iface := d.Interface
 		if iface == "" {
 			iface = fmt.Sprintf("scsi%d", i)
 		}
+		backend, shared := resolveStorage(d)
 		opts.Disks = append(opts.Disks, proxmox.DiskSpec{
 			Interface: iface,
-			Storage:   firstNonEmpty(d.Storage, d.StorageClass, "local-lvm"),
+			Storage:   backend,
 			Size:      d.Size,
-			Shared:    d.Shared,
+			Shared:    shared,
 		})
 	}
 	// NICs
@@ -362,7 +401,6 @@ func buildCreateOpts(env *config.Env, nodeName string, node *config.Node, r *res
 	if r != nil && r.iso != nil && r.iso.Image != "" && r.iso.Storage != "" {
 		opts.ISOFile = fmt.Sprintf("%s:iso/%s", r.iso.Storage, r.iso.Image)
 	}
-	_ = env
 	return opts
 }
 

--- a/pkg/workflow/single_vm_test.go
+++ b/pkg/workflow/single_vm_test.go
@@ -719,13 +719,21 @@ func TestUp_VerifyWarns(t *testing.T) {
 }
 
 func TestBuildCreateOpts_OVMF_StorageClass(t *testing.T) {
+	// Post-#25: storage_class is resolved against env.Spec.StorageClasses,
+	// not passed through as a literal Proxmox storage name.
 	env := testEnv()
 	node := env.Spec.Hypervisor.Inline.Nodes["web01"]
 	node.Resources.BIOS = "ovmf"
-	// Disk uses StorageClass fallback (no direct Storage set).
 	node.Disks[0].Storage = ""
 	node.Disks[0].StorageClass = "fast-ssd"
 	env.Spec.Hypervisor.Inline.Nodes["web01"] = node
+	// Provide a StorageClasses catalogue mapping fast-ssd → nvme-pool.
+	env.Spec.StorageClasses.Inline = &config.StorageClasses{
+		Kind: "StorageClasses",
+		Classes: map[string]config.StorageClass{
+			"fast-ssd": {Backend: "nvme-pool"},
+		},
+	}
 	hyp := env.Spec.Hypervisor.Resolved()
 	n := hyp.Nodes["web01"]
 	r := &resolved{hyp: hyp, node: n, ks: hyp.Kickstart, iso: hyp.ISO}
@@ -733,8 +741,60 @@ func TestBuildCreateOpts_OVMF_StorageClass(t *testing.T) {
 	if opts.EFIDisk == nil {
 		t.Errorf("expected EFIDisk for ovmf")
 	}
-	if opts.Disks[0].Storage != "fast-ssd" {
-		t.Errorf("want fast-ssd got %q", opts.Disks[0].Storage)
+	if opts.Disks[0].Storage != "nvme-pool" {
+		t.Errorf("storage_class not resolved: want nvme-pool got %q", opts.Disks[0].Storage)
+	}
+	if opts.EFIDisk.Storage != "nvme-pool" {
+		t.Errorf("EFIDisk.Storage not resolved from StorageClasses: want nvme-pool got %q", opts.EFIDisk.Storage)
+	}
+}
+
+func TestBuildCreateOpts_StorageClass_PropagatesShared(t *testing.T) {
+	// A storage_class with shared:true on the catalogue side should propagate
+	// to DiskSpec.Shared (proxmox API needs `shared=1` for shared storages).
+	env := testEnv()
+	node := env.Spec.Hypervisor.Inline.Nodes["web01"]
+	node.Disks[0].Storage = ""
+	node.Disks[0].StorageClass = "san-shared"
+	env.Spec.Hypervisor.Inline.Nodes["web01"] = node
+	env.Spec.StorageClasses.Inline = &config.StorageClasses{
+		Kind: "StorageClasses",
+		Classes: map[string]config.StorageClass{
+			"san-shared": {Backend: "iscsi-prod", Shared: true},
+		},
+	}
+	hyp := env.Spec.Hypervisor.Resolved()
+	n := hyp.Nodes["web01"]
+	r := &resolved{hyp: hyp, node: n}
+	opts := buildCreateOpts(env, "web01", &n, r)
+	if opts.Disks[0].Storage != "iscsi-prod" {
+		t.Errorf("backend: want iscsi-prod got %q", opts.Disks[0].Storage)
+	}
+	if !opts.Disks[0].Shared {
+		t.Errorf("Shared=true not propagated from StorageClass.Shared")
+	}
+}
+
+func TestBuildCreateOpts_StorageClass_LiteralStorageWins(t *testing.T) {
+	// When both Disk.Storage (literal) and Disk.StorageClass are set, the
+	// literal Storage wins — operators can override the catalogue per-disk.
+	env := testEnv()
+	node := env.Spec.Hypervisor.Inline.Nodes["web01"]
+	node.Disks[0].Storage = "override-store"
+	node.Disks[0].StorageClass = "fast-ssd"
+	env.Spec.Hypervisor.Inline.Nodes["web01"] = node
+	env.Spec.StorageClasses.Inline = &config.StorageClasses{
+		Kind: "StorageClasses",
+		Classes: map[string]config.StorageClass{
+			"fast-ssd": {Backend: "nvme-pool"},
+		},
+	}
+	hyp := env.Spec.Hypervisor.Resolved()
+	n := hyp.Nodes["web01"]
+	r := &resolved{hyp: hyp, node: n}
+	opts := buildCreateOpts(env, "web01", &n, r)
+	if opts.Disks[0].Storage != "override-store" {
+		t.Errorf("literal Storage should win: want override-store got %q", opts.Disks[0].Storage)
 	}
 }
 


### PR DESCRIPTION
Fixes proxctl create-vm 500 when stack uses storage_class. Resolves via env.Spec.StorageClasses. Closes #25.