### PR TITLE
fix: CreateVM form encoding for disk/NIC/tags (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.28.5 — 2026-04-28
+
+### fix: CreateVM form encoding for disk/NIC/tags (#27)
+
+Three serializer bugs in `pkg/proxmox/vm.go` caused Proxmox to reject
+`POST /nodes/{node}/qemu` with `400 Parameter verification failed`
+(duplicate-key errors on `scsi0`, `net0`; tags split mid-string):
+
+1. `DiskString` always emitted `format=raw`. Proxmox rejects an explicit
+   `format=` on `lvmthin` / `zfspool` storage with
+   "duplicate key in comma-separated list property: file". Fix: omit
+   `format=` unless caller explicitly sets `DiskSpec.Format`.
+
+2. `NICString` emitted bare `<model>,bridge=...` when MAC was empty/auto,
+   which Proxmox parses as a duplicate `model` key. Fix: always emit
+   `<model>=<mac>` (with `mac=auto` as the default sentinel).
+
+3. `CreateVM` joined `Tags` with `;`. Proxmox's form parser splits the
+   query body on `;` first, so multi-tag values were spilling into
+   adjacent params. Fix: join with `,` (Proxmox's documented separator).
+
+Tests in `pkg/proxmox/vm_test.go` updated for new expected wire forms.
+
+Caught while running `/lab-up --phase B` for ext3+ext4 in
+itunified-io/infrastructure (plan 034) — fifth gate after .1–.4.
+
 ## v2026.04.28.4 — 2026-04-28
 
 ### fix: buildCreateOpts resolves storage_class → backend (#25)

--- a/pkg/proxmox/vm.go
+++ b/pkg/proxmox/vm.go
@@ -108,12 +108,10 @@ func (o CreateOpts) Validate() error {
 //
 //	<storage>:<size>[,format=<fmt>][,shared=1]
 func (d DiskSpec) DiskString() string {
-	format := d.Format
-	if format == "" {
-		format = "raw"
-	}
 	parts := []string{fmt.Sprintf("%s:%s", d.Storage, d.Size)}
-	parts = append(parts, "format="+format)
+	if d.Format != "" {
+		parts = append(parts, "format="+d.Format)
+	}
 	if d.Shared {
 		parts = append(parts, "shared=1")
 	}
@@ -128,11 +126,11 @@ func (n NICSpec) NICString() string {
 	if model == "" {
 		model = "virtio"
 	}
-	head := model
-	if n.MAC != "" && !strings.EqualFold(n.MAC, "auto") {
-		head = model + "=" + n.MAC
+	mac := n.MAC
+	if mac == "" || strings.EqualFold(mac, "auto") {
+		mac = "auto"
 	}
-	parts := []string{head, "bridge=" + n.Bridge}
+	parts := []string{model + "=" + mac, "bridge=" + n.Bridge}
 	if n.Firewall {
 		parts = append(parts, "firewall=1")
 	}
@@ -196,7 +194,7 @@ func (c *Client) CreateVM(ctx context.Context, opts CreateOpts) error {
 		form.Set("ostype", opts.OSType)
 	}
 	if len(opts.Tags) > 0 {
-		form.Set("tags", strings.Join(opts.Tags, ";"))
+		form.Set("tags", strings.Join(opts.Tags, ","))
 	}
 	form.Set("agent", "1")
 	if opts.StartAtBoot {

--- a/pkg/proxmox/vm_test.go
+++ b/pkg/proxmox/vm_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestDiskAndNICAndEFIString(t *testing.T) {
 	d := DiskSpec{Interface: "scsi0", Storage: "local-lvm", Size: "64G", Shared: true}
-	assert.Equal(t, "local-lvm:64G,format=raw,shared=1", d.DiskString())
+	assert.Equal(t, "local-lvm:64G,shared=1", d.DiskString())
 
 	d2 := DiskSpec{Interface: "scsi1", Storage: "ssd", Size: "100G", Format: "qcow2"}
 	assert.Equal(t, "ssd:100G,format=qcow2", d2.DiskString())
@@ -27,7 +27,7 @@ func TestDiskAndNICAndEFIString(t *testing.T) {
 	assert.Equal(t, "virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0,firewall=1,tag=10", n.NICString())
 
 	n2 := NICSpec{Index: 1, Bridge: "vmbr1", MAC: "auto"}
-	assert.Equal(t, "virtio,bridge=vmbr1", n2.NICString())
+	assert.Equal(t, "virtio=auto,bridge=vmbr1", n2.NICString())
 
 	e := EFIDiskSpec{Storage: "local-lvm", PreEnrolledKeys: true}
 	assert.Equal(t, "local-lvm:1,format=raw,efitype=4m,pre-enrolled-keys=1", e.EFIDiskString())
@@ -122,13 +122,13 @@ func TestCreateVM_FormFieldsAndTaskPolling(t *testing.T) {
 	assert.Equal(t, "q35", body.Get("machine"))
 	assert.Equal(t, "virtio-scsi-single", body.Get("scsihw"))
 	assert.Equal(t, "l26", body.Get("ostype"))
-	assert.Equal(t, "oel9;lab", body.Get("tags"))
+	assert.Equal(t, "oel9,lab", body.Get("tags"))
 	assert.Equal(t, "1", body.Get("agent"))
 	assert.Equal(t, "1", body.Get("onboot"))
 	assert.Equal(t, "1", body.Get("protection"))
 	assert.Equal(t, "local-lvm:1,format=raw,efitype=4m,pre-enrolled-keys=0", body.Get("efidisk0"))
-	assert.Equal(t, "local-lvm:64G,format=raw", body.Get("scsi0"))
-	assert.Equal(t, "virtio,bridge=vmbr0", body.Get("net0"))
+	assert.Equal(t, "local-lvm:64G", body.Get("scsi0"))
+	assert.Equal(t, "virtio=auto,bridge=vmbr0", body.Get("net0"))
 	assert.Equal(t, "proxmox:iso/oel9.iso,media=cdrom", body.Get("ide2"))
 	assert.Equal(t, "application/x-www-form-urlencoded", f.requests[0].CT)
 }


### PR DESCRIPTION
Closes #27

Three serializer bugs in pkg/proxmox/vm.go fixed:
1. DiskString — omit format= unless explicit (lvmthin/zfspool rejection)
2. NICString — always emit <model>=<mac> with mac=auto sentinel
3. Tags — join with ',' not ';'

Tests updated. Build + full test suite green.