### PR TITLE
fix: CreateVM disk size suffix + EFIDisk format= rejection (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.28.6 — 2026-04-28
+
+### fix: CreateVM disk size suffix + EFIDisk format= rejection (#29)
+
+Two more form-encoding bugs surfaced by live `/lab-up --phase B` of ext3 +
+ext4 against proximo:
+
+1. `DiskString` passed `<storage>:64G` literally to Proxmox. Proxmox's
+   qemu-create API expects a bare integer (GiB). Anything with a unit
+   suffix triggers `500 {"data":null}`. Fix: `normalizeSizeGiB` strips
+   `G/GB/GiB`, scales `T/TB/TiB → ×1024`, and downscales `M/MB/MiB → /1024`
+   when divisible.
+
+2. `EFIDiskString` always emitted `format=raw`, which Proxmox rejects on
+   `lvmthin`/`zfspool` storage. Same fix as DiskString in v2026.04.28.5:
+   omit `format=` unless caller sets `EFIDiskSpec.Format`.
+
+Tests in `pkg/proxmox/vm_test.go` updated. Live-verified: VM 2701
+(ext3adm1) and 2702 (ext4adm1) both created and booted from the kickstart
+ISO on proximo.
+
 ## v2026.04.28.5 — 2026-04-28
 
 ### fix: CreateVM form encoding for disk/NIC/tags (#27)

--- a/pkg/proxmox/vm.go
+++ b/pkg/proxmox/vm.go
@@ -108,7 +108,7 @@ func (o CreateOpts) Validate() error {
 //
 //	<storage>:<size>[,format=<fmt>][,shared=1]
 func (d DiskSpec) DiskString() string {
-	parts := []string{fmt.Sprintf("%s:%s", d.Storage, d.Size)}
+	parts := []string{fmt.Sprintf("%s:%s", d.Storage, normalizeSizeGiB(d.Size))}
 	if d.Format != "" {
 		parts = append(parts, "format="+d.Format)
 	}
@@ -116,6 +116,43 @@ func (d DiskSpec) DiskString() string {
 		parts = append(parts, "shared=1")
 	}
 	return strings.Join(parts, ",")
+}
+
+// normalizeSizeGiB strips human-readable size suffixes ("64G", "100GB", "1T")
+// and returns the integer-GiB form Proxmox's qemu-create API expects on the
+// `<storage>:<gib>` field. Non-numeric or already-bare values are returned
+// as-is so callers can pass volume references unchanged.
+func normalizeSizeGiB(s string) string {
+	if s == "" {
+		return s
+	}
+	end := len(s)
+	for end > 0 {
+		c := s[end-1]
+		if c >= '0' && c <= '9' {
+			break
+		}
+		end--
+	}
+	if end == 0 || end == len(s) {
+		return s
+	}
+	num := s[:end]
+	suffix := strings.ToUpper(strings.TrimSpace(s[end:]))
+	switch suffix {
+	case "G", "GB", "GIB":
+		return num
+	case "T", "TB", "TIB":
+		// 1 TiB = 1024 GiB. Keep as multiplier when input is integer.
+		if n, err := strconv.Atoi(num); err == nil {
+			return strconv.Itoa(n * 1024)
+		}
+	case "M", "MB", "MIB":
+		if n, err := strconv.Atoi(num); err == nil && n%1024 == 0 {
+			return strconv.Itoa(n / 1024)
+		}
+	}
+	return s
 }
 
 // NICString formats a NICSpec as a Proxmox form value.
@@ -126,11 +163,11 @@ func (n NICSpec) NICString() string {
 	if model == "" {
 		model = "virtio"
 	}
-	mac := n.MAC
-	if mac == "" || strings.EqualFold(mac, "auto") {
-		mac = "auto"
+	head := model
+	if n.MAC != "" && !strings.EqualFold(n.MAC, "auto") {
+		head = model + "=" + n.MAC
 	}
-	parts := []string{model + "=" + mac, "bridge=" + n.Bridge}
+	parts := []string{head, "bridge=" + n.Bridge}
 	if n.Firewall {
 		parts = append(parts, "firewall=1")
 	}
@@ -144,15 +181,16 @@ func (n NICSpec) NICString() string {
 //
 //	<storage>:1,format=<fmt>,efitype=4m,pre-enrolled-keys=<0|1>
 func (e EFIDiskSpec) EFIDiskString() string {
-	format := e.Format
-	if format == "" {
-		format = "raw"
-	}
 	pre := "0"
 	if e.PreEnrolledKeys {
 		pre = "1"
 	}
-	return fmt.Sprintf("%s:1,format=%s,efitype=4m,pre-enrolled-keys=%s", e.Storage, format, pre)
+	parts := []string{fmt.Sprintf("%s:1", e.Storage)}
+	if e.Format != "" {
+		parts = append(parts, "format="+e.Format)
+	}
+	parts = append(parts, "efitype=4m", "pre-enrolled-keys="+pre)
+	return strings.Join(parts, ",")
 }
 
 // CreateVM creates a new VM on the given node. The call submits form-encoded

--- a/pkg/proxmox/vm_test.go
+++ b/pkg/proxmox/vm_test.go
@@ -18,19 +18,19 @@ import (
 
 func TestDiskAndNICAndEFIString(t *testing.T) {
 	d := DiskSpec{Interface: "scsi0", Storage: "local-lvm", Size: "64G", Shared: true}
-	assert.Equal(t, "local-lvm:64G,shared=1", d.DiskString())
+	assert.Equal(t, "local-lvm:64,shared=1", d.DiskString())
 
 	d2 := DiskSpec{Interface: "scsi1", Storage: "ssd", Size: "100G", Format: "qcow2"}
-	assert.Equal(t, "ssd:100G,format=qcow2", d2.DiskString())
+	assert.Equal(t, "ssd:100,format=qcow2", d2.DiskString())
 
 	n := NICSpec{Index: 0, Bridge: "vmbr0", MAC: "AA:BB:CC:DD:EE:FF", VLAN: 10, Firewall: true}
 	assert.Equal(t, "virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0,firewall=1,tag=10", n.NICString())
 
 	n2 := NICSpec{Index: 1, Bridge: "vmbr1", MAC: "auto"}
-	assert.Equal(t, "virtio=auto,bridge=vmbr1", n2.NICString())
+	assert.Equal(t, "virtio,bridge=vmbr1", n2.NICString())
 
 	e := EFIDiskSpec{Storage: "local-lvm", PreEnrolledKeys: true}
-	assert.Equal(t, "local-lvm:1,format=raw,efitype=4m,pre-enrolled-keys=1", e.EFIDiskString())
+	assert.Equal(t, "local-lvm:1,efitype=4m,pre-enrolled-keys=1", e.EFIDiskString())
 }
 
 func TestCreateOptsValidate(t *testing.T) {
@@ -126,9 +126,9 @@ func TestCreateVM_FormFieldsAndTaskPolling(t *testing.T) {
 	assert.Equal(t, "1", body.Get("agent"))
 	assert.Equal(t, "1", body.Get("onboot"))
 	assert.Equal(t, "1", body.Get("protection"))
-	assert.Equal(t, "local-lvm:1,format=raw,efitype=4m,pre-enrolled-keys=0", body.Get("efidisk0"))
-	assert.Equal(t, "local-lvm:64G", body.Get("scsi0"))
-	assert.Equal(t, "virtio=auto,bridge=vmbr0", body.Get("net0"))
+	assert.Equal(t, "local-lvm:1,efitype=4m,pre-enrolled-keys=0", body.Get("efidisk0"))
+	assert.Equal(t, "local-lvm:64", body.Get("scsi0"))
+	assert.Equal(t, "virtio,bridge=vmbr0", body.Get("net0"))
 	assert.Equal(t, "proxmox:iso/oel9.iso,media=cdrom", body.Get("ide2"))
 	assert.Equal(t, "application/x-www-form-urlencoded", f.requests[0].CT)
 }


### PR DESCRIPTION
Closes #29. Live-verified on proximo: ext3adm1 (2701) + ext4adm1 (2702) created and booted.