### PR TITLE
fix: workflow up never attached kickstart ISO to VM (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.28.7 — 2026-04-29
+
+### fix: workflow up never attached kickstart ISO to VM (#31)
+
+The single-VM workflow `apply` phase rendered/built/uploaded the kickstart
+ISO to Proxmox storage but never attached it to the VM. The `create-vm`
+step only attached the install ISO (ide2). With no OEMDRV-labeled CDROM
+discoverable, Anaconda fell back to interactive mode and hung at the
+language-select screen forever.
+
+This affected BOTH the normal flow and `--skip-kickstart-build`. Symptom:
+VMs run for hours with no install progress, no SSH, no ping; VM config
+shows `boot=order=scsi0;ide2;net0` (default) and only `ide2`, no `ide3`.
+
+`pkg/proxmox/boot.go` already shipped `AttachISOAsCDROM` and `SetBootOrder`
+(plus a higher-level `ConfigureFirstBoot`) — they were just never wired
+into the workflow.
+
+Fix: new `attach-kickstart-iso` Change step inserted between `create-vm`
+and `start-vm` in `Plan()`. `Apply()` calls
+`AttachISOAsCDROM(node, vmid, "ide3", <ks-volid>)` followed by
+`SetBootOrder(node, vmid, "scsi0;ide3;ide2")`. Step is conditional on
+`iso.kickstart_storage` being configured (same gate as upload-iso /
+verify-kickstart-iso).
+
+Tests: `TestPlan` and `TestPlan_SkipKickstartBuild` updated for the new
+6/4-step plans (was 5/3).
+
+Caught while running `/lab-up --phase B` for ext3+ext4 — VMs ran 12+
+hours with no progress until the workaround (manual ide3 attach + boot
+reorder + restart) was applied.
+
 ## v2026.04.28.6 — 2026-04-28
 
 ### fix: CreateVM disk size suffix + EFIDisk format= rejection (#29)

--- a/pkg/workflow/single_vm.go
+++ b/pkg/workflow/single_vm.go
@@ -135,6 +135,16 @@ func (w *SingleVMWorkflow) Plan(ctx context.Context) ([]Change, error) {
 				"nics":   len(r.node.NICs),
 			},
 		},
+	)
+	if r.iso != nil && r.iso.KickstartStorage != "" {
+		changes = append(changes, Change{
+			Kind:   "attach-kickstart-iso",
+			Target: fmt.Sprintf("%s/%d", r.node.Proxmox.NodeName, r.node.Proxmox.VMID),
+			Description: fmt.Sprintf("attach kickstart ISO to ide3 + set boot order (scsi0;ide3;ide2) on VM %d",
+				r.node.Proxmox.VMID),
+		})
+	}
+	changes = append(changes,
 		Change{Kind: "start-vm", Target: fmt.Sprintf("%s/%d", r.node.Proxmox.NodeName, r.node.Proxmox.VMID),
 			Description: fmt.Sprintf("start VM %d", r.node.Proxmox.VMID)},
 	)
@@ -215,6 +225,20 @@ func (w *SingleVMWorkflow) Apply(ctx context.Context, changes []Change) error {
 			opts := buildCreateOpts(w.Config, w.NodeName, &r.node, r)
 			if err := w.Client.CreateVM(ctx, opts); err != nil {
 				return fmt.Errorf("create-vm: %w", err)
+			}
+		case "attach-kickstart-iso":
+			if w.Client == nil {
+				return errors.New("apply: Client not set")
+			}
+			if r.iso == nil || r.iso.KickstartStorage == "" {
+				return errors.New("apply: iso.kickstart_storage not configured (cannot attach kickstart ISO)")
+			}
+			ksVolID := fmt.Sprintf("%s:iso/%s_kickstart.iso", r.iso.KickstartStorage, w.NodeName)
+			if err := w.Client.AttachISOAsCDROM(ctx, r.node.Proxmox.NodeName, r.node.Proxmox.VMID, "ide3", ksVolID); err != nil {
+				return fmt.Errorf("attach-kickstart-iso: %w", err)
+			}
+			if err := w.Client.SetBootOrder(ctx, r.node.Proxmox.NodeName, r.node.Proxmox.VMID, "scsi0;ide3;ide2"); err != nil {
+				return fmt.Errorf("attach-kickstart-iso: set boot order: %w", err)
 			}
 		case "start-vm":
 			if w.Client == nil {

--- a/pkg/workflow/single_vm_test.go
+++ b/pkg/workflow/single_vm_test.go
@@ -91,7 +91,7 @@ func TestPlan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
-	wantKinds := []string{"render-kickstart", "build-iso", "upload-iso", "create-vm", "start-vm"}
+	wantKinds := []string{"render-kickstart", "build-iso", "upload-iso", "create-vm", "attach-kickstart-iso", "start-vm"}
 	if len(changes) != len(wantKinds) {
 		t.Fatalf("want %d changes got %d: %+v", len(wantKinds), len(changes), changes)
 	}
@@ -124,7 +124,7 @@ func TestPlan_SkipKickstartBuild(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
-	wantKinds := []string{"verify-kickstart-iso", "create-vm", "start-vm"}
+	wantKinds := []string{"verify-kickstart-iso", "create-vm", "attach-kickstart-iso", "start-vm"}
 	if len(changes) != len(wantKinds) {
 		t.Fatalf("want %d changes got %d: %+v", len(wantKinds), len(changes), changes)
 	}


### PR DESCRIPTION
Closes #31. Wires existing AttachISOAsCDROM + SetBootOrder helpers into the workflow's apply phase via a new attach-kickstart-iso Change step. Live-verified on proximo: ext3adm1 (2701) and ext4adm1 (2702) — manual workaround is now codified.