### PR TITLE
fix: kickstart 'reboot --eject' to break install loop (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.28.8 — 2026-04-29
+
+### fix: kickstart `reboot --eject` to break install loop (#33)
+
+OEL8/OEL9 base.ks templates emitted plain `reboot`. After Anaconda finished
+the install and rebooted, the install ISO stayed attached on `ide2`. With
+SeaBIOS boot order `scsi0;ide3;ide2`, any time scsi0 was slow to handshake
+or the freshly-installed bootloader hadn't been activated yet, BIOS fell
+through to ide2 and re-launched Anaconda — install loop, indefinitely.
+
+Fix: emit `reboot --eject` so Anaconda pops the install ISO on the way out;
+the next boot has nothing on ide2 to fall through to.
+
+Caught while running `/lab-up --phase B` for ext3+ext4 — VMs cycled through
+the install screen multiple times before being diagnosed.
+
 ## v2026.04.28.7 — 2026-04-29
 
 ### fix: workflow up never attached kickstart ISO to VM (#31)

--- a/pkg/kickstart/templates/oraclelinux8/base.ks.tmpl
+++ b/pkg/kickstart/templates/oraclelinux8/base.ks.tmpl
@@ -25,7 +25,7 @@ services --enabled="chronyd,sshd" --disabled="postfix"
 user --name={{ $u.Name }}{{ if $u.Wheel }} --groups=wheel{{ end }}
 {{- end }}
 
-reboot
+reboot --eject
 
 %packages
 @base

--- a/pkg/kickstart/templates/oraclelinux9/base.ks.tmpl
+++ b/pkg/kickstart/templates/oraclelinux9/base.ks.tmpl
@@ -38,8 +38,11 @@ services --enabled="chronyd,sshd"
 user --name={{ $u.Name }}{{ if $u.Wheel }} --groups=wheel{{ end }}
 {{- end }}
 
-# Reboot after install
-reboot
+# Reboot after install. --eject pops the CDROM tray on the install ISO so
+# SeaBIOS doesn't fall through to it on next boot and re-enter Anaconda —
+# without --eject, ide2 stays attached after install and BIOS boot fallthrough
+# (when scsi0 boot is briefly delayed) hits the install ISO → install loop.
+reboot --eject
 
 %packages
 @^minimal-environment


### PR DESCRIPTION
Closes #33. One-line fix in OEL8/OEL9 templates.