### PR TITLE
fix: NM keyfile for static NIC config on OEL8/OEL9 (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.28.9 — 2026-04-29
+
+### fix: NetworkManager keyfile for static NIC config on OEL8/OEL9 (#35)
+
+Anaconda's `network --bootproto=static --activate --onboot=yes` writes
+legacy `/etc/sysconfig/network-scripts/ifcfg-<dev>` files. On OEL9 (and
+increasingly OEL8) the NetworkManager daemon prefers keyfile format
+(`/etc/NetworkManager/system-connections/<id>.nmconnection`) and on first
+boot auto-creates a fresh **DHCP** profile when no keyfile exists for the
+interface. The legacy ifcfg file is silently ignored, so the installed
+system comes up on DHCP — not the configured static IP.
+
+Fix: new `common/nm_keyfile.tmpl` template emits a `%post` that writes a
+NetworkManager keyfile per static NIC, removes any stale ifcfg/keyfile
+that could create profile races, and sets `autoconnect-priority=100` so
+NM doesn't create a competing default-named profile.
+
+Wired into both `oraclelinux9/base.ks.tmpl` and `oraclelinux8/base.ks.tmpl`.
+Live-verified: ext3adm1 / ext4adm1 came up at the wrong DHCP IPs (.103/.104)
+on first install — the OPNsense static reservations were correct but
+NM ignored them.
+
 ## v2026.04.28.8 — 2026-04-29
 
 ### fix: kickstart `reboot --eject` to break install loop (#33)

--- a/pkg/kickstart/templates/common/nm_keyfile.tmpl
+++ b/pkg/kickstart/templates/common/nm_keyfile.tmpl
@@ -1,0 +1,56 @@
+{{- /*
+  nm_keyfile — emits a %post that writes a NetworkManager keyfile per
+  static NIC. This is needed on OEL9/RHEL9 where NM no longer picks up
+  legacy /etc/sysconfig/network-scripts/ifcfg-* files emitted by
+  Anaconda's `network --bootproto=static` directive. Without a keyfile
+  in /etc/NetworkManager/system-connections/, NM auto-creates a default
+  DHCP profile on first boot and the static config is silently ignored.
+
+  We re-do the work in %post so the installed system reliably comes up
+  on the configured static IP. ifcfg files (if any) are removed to
+  prevent duplicate-profile races.
+*/ -}}
+{{- define "nm_keyfile" -}}
+{{- $hasStatic := false -}}
+{{- range $nic := .Node.NICs }}{{- if and $nic.IPv4 (eq $nic.Bootproto "static") }}{{- $hasStatic = true }}{{- end }}{{- end }}
+{{- if $hasStatic }}
+# NetworkManager keyfiles for static NICs (works around Anaconda
+# writing legacy ifcfg-* files that OEL9 NetworkManager ignores).
+%post --erroronfail
+set -e
+mkdir -p /etc/NetworkManager/system-connections
+{{- range $nic := .Node.NICs }}
+{{- if and $nic.IPv4 (eq $nic.Bootproto "static") }}
+# Remove any stale ifcfg / nmconnection for {{ $nic.NameField }} so we own the profile.
+rm -f /etc/sysconfig/network-scripts/ifcfg-{{ $nic.NameField }} || true
+rm -f /etc/NetworkManager/system-connections/{{ $nic.NameField }}.nmconnection || true
+rm -f "/etc/NetworkManager/system-connections/Wired connection 1.nmconnection" || true
+cat > /etc/NetworkManager/system-connections/{{ $nic.NameField }}.nmconnection <<'NMEOF'
+[connection]
+id={{ $nic.NameField }}
+type=ethernet
+interface-name={{ $nic.NameField }}
+autoconnect=true
+autoconnect-priority=100
+
+[ethernet]
+
+[ipv4]
+method=manual
+address1={{ cidrIP $nic.IPv4.Address }}/{{ cidrPrefix $nic.IPv4.Address }}{{ if $nic.IPv4.Gateway }},{{ $nic.IPv4.Gateway }}{{ end }}
+{{- if $nic.IPv4.DNS }}
+dns={{ join ";" $nic.IPv4.DNS }};
+{{- end }}
+may-fail=false
+
+[ipv6]
+method=disabled
+
+[proxy]
+NMEOF
+chmod 600 /etc/NetworkManager/system-connections/{{ $nic.NameField }}.nmconnection
+{{- end }}
+{{- end }}
+%end
+{{- end }}
+{{- end -}}

--- a/pkg/kickstart/templates/oraclelinux8/base.ks.tmpl
+++ b/pkg/kickstart/templates/oraclelinux8/base.ks.tmpl
@@ -48,6 +48,8 @@ rsync
 
 {{ template "post_common" . }}
 
+{{ template "nm_keyfile" . }}
+
 # SSH keys
 %post --erroronfail
 mkdir -p /root/.ssh && chmod 700 /root/.ssh

--- a/pkg/kickstart/templates/oraclelinux9/base.ks.tmpl
+++ b/pkg/kickstart/templates/oraclelinux9/base.ks.tmpl
@@ -62,6 +62,8 @@ rsync
 
 {{ template "post_common" . }}
 
+{{ template "nm_keyfile" . }}
+
 # SSH keys
 %post --erroronfail
 mkdir -p /root/.ssh && chmod 700 /root/.ssh


### PR DESCRIPTION
Closes #35. Adds common/nm_keyfile.tmpl. Live-verified on ext3+ext4 install.