### PR TITLE
fix: kickstart unattended-install hang (#39)

### DIFF
--- a/pkg/config/hypervisor.go
+++ b/pkg/config/hypervisor.go
@@ -90,6 +90,12 @@ type KickstartConfig struct {
 	ChronyServers   []string            `yaml:"chrony_servers,omitempty"   json:"chrony_servers,omitempty"`
 	Sudo            *SudoConfig         `yaml:"sudo,omitempty"             json:"sudo,omitempty"`
 	Packages        *PackagesConfig     `yaml:"packages,omitempty"         json:"packages,omitempty"`
+	// Repos — extra `repo` directives written into the kickstart so packages
+	// from non-default repos (e.g. oracle-database-preinstall-19c from
+	// ol9_oracle_software) resolve at install time. When empty, the OEL9/OEL8
+	// templates fall back to a sensible default set (yum.oracle.com mirrors).
+	// Set this to override (e.g. internal Pulp/Foreman mirror).
+	Repos           []KickstartRepo     `yaml:"repos,omitempty"            json:"repos,omitempty"`
 	Firewall        *KSFirewall         `yaml:"firewall,omitempty"         json:"firewall,omitempty"`
 	UpdateSystem    bool                `yaml:"update_system,omitempty"    json:"update_system,omitempty"`
 	SSHKeys         map[string][]string `yaml:"ssh_keys,omitempty"         json:"ssh_keys,omitempty"`
@@ -99,6 +105,15 @@ type KickstartConfig struct {
 // SudoConfig captures sudoers-style flags.
 type SudoConfig struct {
 	WheelNopasswd bool `yaml:"wheel_nopasswd,omitempty" json:"wheel_nopasswd,omitempty"`
+}
+
+// KickstartRepo is a single `repo` directive emitted into the kickstart.
+// One of BaseURL or MirrorList must be set.
+type KickstartRepo struct {
+	Name       string `yaml:"name"                  json:"name"                  validate:"required"`
+	BaseURL    string `yaml:"baseurl,omitempty"     json:"baseurl,omitempty"`
+	MirrorList string `yaml:"mirrorlist,omitempty"  json:"mirrorlist,omitempty"`
+	Cost       int    `yaml:"cost,omitempty"        json:"cost,omitempty"`
 }
 
 // PackagesConfig enumerates base and post-install package lists.

--- a/pkg/kickstart/templates/oraclelinux8/base.ks.tmpl
+++ b/pkg/kickstart/templates/oraclelinux8/base.ks.tmpl
@@ -27,7 +27,19 @@ user --name={{ $u.Name }}{{ if $u.Wheel }} --groups=wheel{{ end }}
 
 reboot --eject
 
-%packages
+# Repos — base + Oracle Software (see oraclelinux9/base.ks.tmpl for rationale).
+{{- if .Kickstart.Repos }}
+{{- range $r := .Kickstart.Repos }}
+repo --name={{ $r.Name }}{{ if $r.BaseURL }} --baseurl={{ $r.BaseURL }}{{ end }}{{ if $r.MirrorList }} --mirrorlist={{ $r.MirrorList }}{{ end }}
+{{- end }}
+{{- else }}
+repo --name=ol8_appstream --baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/
+repo --name=ol8_baseos_latest --baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64/
+repo --name=ol8_oracle_software --baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/oracle/software/x86_64/
+{{- end }}
+
+# --ignoremissing: never block unattended install on missing pkg prompt.
+%packages --ignoremissing
 @base
 @core
 chrony

--- a/pkg/kickstart/templates/oraclelinux9/base.ks.tmpl
+++ b/pkg/kickstart/templates/oraclelinux9/base.ks.tmpl
@@ -44,7 +44,30 @@ user --name={{ $u.Name }}{{ if $u.Wheel }} --groups=wheel{{ end }}
 # (when scsi0 boot is briefly delayed) hits the install ISO → install loop.
 reboot --eject
 
-%packages
+# Repos — base ISO + Oracle Software for Enterprise Linux (yum.oracle.com).
+# Without an Oracle repo, packages like oracle-database-preinstall-19c (the
+# Oracle DB prerequisites RPM) aren't resolvable at install time and Anaconda
+# halts on an interactive prompt. Mirror via the official Oracle yum
+# repository — public, no MOS account needed, signed.
+{{- if .Kickstart.Repos }}
+{{- range $r := .Kickstart.Repos }}
+repo --name={{ $r.Name }}{{ if $r.BaseURL }} --baseurl={{ $r.BaseURL }}{{ end }}{{ if $r.MirrorList }} --mirrorlist={{ $r.MirrorList }}{{ end }}{{ if $r.Cost }} --cost={{ $r.Cost }}{{ end }}
+{{- end }}
+{{- else }}
+# Default Oracle Software repo. Override via Kickstart.Repos in env.yaml.
+repo --name=ol9_appstream --baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/
+repo --name=ol9_baseos --baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/
+repo --name=ol9_oracle_software --baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/oracle/software/x86_64/
+repo --name=ol9_UEKR7 --baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/UEKR7/x86_64/
+{{- end }}
+
+# --ignoremissing: do NOT halt on interactive prompt if a package can't be
+# resolved at install time (e.g. transient repo outage, package renamed
+# between releases). Unattended kickstart must never block on yes/no.
+# Missing pkgs get logged + skipped; linuxctl Phase C re-installs anything
+# critical via dnf with the same Oracle repos, so a missing kickstart pkg
+# is never the final state.
+%packages --ignoremissing
 @^minimal-environment
 @core
 chrony


### PR DESCRIPTION
Adds --ignoremissing + Oracle yum.oracle.com repo defaults. Live-caught Apr 30 — install blocked 57 min on missing oracle-database-preinstall-19c prompt.