### PR TITLE
fix: Database.Kind accepts ADR-0097 snake_case target types (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.30.3 — 2026-04-30
+
+### fix: Database.Kind accepts ADR-0097 snake_case target types (#43)
+
+`pkg/config/database.go` validator only allowed legacy CamelCase
+(`OracleDatabase`, `PostgresDatabase`). DbSys manifests written per
+ADR-0097 (Oracle Cloud Control target_type alignment) use the
+snake_case form (`oracle_database`, `rac_database`, `pg_database`,
+`pg_cluster`) and failed `proxctl kickstart generate` validation.
+
+Now accepts both legacy + ADR-0097 forms. Sub-target types
+(`oracle_pdb`, `oracle_listener`, `oracle_asm`, `oracle_instance`,
+`oracle_home`, `oracle_dg_topology`, `cluster`, `host`) remain
+forbidden as top-level kinds — they live under `spec.*`.
+
+Caught during /lab-up Phase A.3 (infrastructure issue #479) on
+2026-04-30.
+
 ## v2026.04.30.1 — 2026-04-30
 
 ### fix: kickstart pins disk partitioning to sda (#39)

--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -7,8 +7,18 @@ import (
 )
 
 // Database is a fully opaque manifest; proxctl does not act on it.
+//
+// Kind accepts both the legacy CamelCase form (`OracleDatabase`,
+// `PostgresDatabase`) and the ADR-0097 Cloud Control target_type form
+// (`oracle_database`, `rac_database`, `pg_database`, `pg_cluster`). The
+// snake_case values mirror Oracle Cloud Control / OEM `mgmt$target.target_type`
+// so DbSys manifests round-trip 1:1 with OEM discovery + `emcli add_target`.
+//
+// Sub-target types (oracle_pdb, oracle_listener, oracle_asm, oracle_instance,
+// oracle_home, oracle_dg_topology, cluster, host) are NOT valid top-level
+// kinds — they live under spec.* of a parent oracle_database / rac_database.
 type Database struct {
-	Kind string         `yaml:"kind" json:"kind" validate:"required,oneof=OracleDatabase PostgresDatabase"`
+	Kind string         `yaml:"kind" json:"kind" validate:"required,oneof=OracleDatabase PostgresDatabase oracle_database rac_database pg_database pg_cluster"`
 	Raw  map[string]any `yaml:"-"    json:"raw,omitempty"`
 }
 

--- a/pkg/config/passthrough_test.go
+++ b/pkg/config/passthrough_test.go
@@ -64,6 +64,25 @@ version: "19.25"
 	}
 }
 
+// TestDatabase_ADR0097Kinds locks in the snake_case Cloud Control target_type
+// values introduced by ADR-0097. Regression guard: agent #479 caught
+// /lab-up Phase A.3 failing because proxctl rejected `oracle_database`.
+func TestDatabase_ADR0097Kinds(t *testing.T) {
+	for _, kind := range []string{
+		"OracleDatabase", "PostgresDatabase", // legacy
+		"oracle_database", "rac_database", "pg_database", "pg_cluster", // ADR-0097
+	} {
+		y := "kind: " + kind + "\nname: TEST\n"
+		var d Database
+		if err := yaml.Unmarshal([]byte(y), &d); err != nil {
+			t.Fatalf("kind=%s: %v", kind, err)
+		}
+		if d.Kind != kind {
+			t.Errorf("kind=%s: got %q", kind, d.Kind)
+		}
+	}
+}
+
 func TestHooks_Roundtrip(t *testing.T) {
 	y := `
 on_apply_success:


### PR DESCRIPTION
## Summary

- Database.Kind validator extended from `OracleDatabase|PostgresDatabase` to also accept `oracle_database|rac_database|pg_database|pg_cluster` (ADR-0097)
- Regression test `TestDatabase_ADR0097Kinds` locks all 6 valid kinds
- CHANGELOG entry for v2026.04.30.3

Caught during /lab-up Phase A.3 on 2026-04-30 — `proxctl kickstart generate` rejected ext3-orcl/ext4-orcl manifests written per ADR-0097.

Closes #43

## Test plan

- [x] `go test ./pkg/config/...` passes
- [x] `go build ./...` succeeds
- [ ] /lab-up Phase A.3 `proxctl kickstart generate` works against ADR-0097 manifests in next session run

🤖 Generated with [Claude Code](https://claude.com/claude-code)