### PR TITLE
feat(kickstart): ubuntu2404 Subiquity autoinstall (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.30.5 — 2026-04-30
+
+### feat: ubuntu2404 Subiquity autoinstall via cidata + GRUB cmdline injection
+
+Ubuntu 22.04.5+ / 24.04 live-server ISOs ship Subiquity (autoinstall via
+cloud-init NoCloud datasource) — no isolinux, no preseed support. Without a
+kernel-cmdline `autoinstall ds=nocloud\;s=/cidata/`, Subiquity prompts the
+operator to confirm, breaking unattended provisioning. The legacy
+`ubuntu2204` preseed template doesn't apply.
+
+This release adds:
+
+- `pkg/kickstart/templates/ubuntu2404/user-data.tmpl` — Subiquity autoinstall
+  template with `interactive-sections: []` (truly unattended), distro-aware
+  Wheel→sudo mapping in late-commands (`Wheel: true` renders `usermod -aG
+  sudo <user>` + sudoers.d entry, since Ubuntu has no `wheel` group), SSH
+  authorized-keys for primary user + root, hostname/keyboard/locale/network
+  rendered from manifest.
+- `pkg/kickstart/templates/ubuntu2404/meta-data.tmpl` — minimal cloud-init
+  meta-data with instance-id keyed on hostname.
+- `pkg/kickstart/ubuntu_iso_builder.go` — repacks the upstream Ubuntu install
+  ISO via xorriso `-indev`/`-outdev` (no 3 GB extraction overhead),
+  preserving original El Torito + UEFI boot images via `-boot_image any
+  replay`. Patches every GRUB `linux`/`linuxefi` line + isolinux `append`
+  line to append `autoinstall ds=nocloud\;s=/cidata/`. Idempotent (skips if
+  `autoinstall` already present). Embeds rendered `user-data` + `meta-data`
+  at `/cidata/` in the ISO root.
+- `pkg/kickstart/renderer.go` — `pickEntry()` recognizes `user-data.tmpl` as
+  a third entry-point in addition to `base.ks.tmpl` (RHEL/OEL kickstart) and
+  `preseed.cfg.tmpl` (legacy Debian preseed).
+- `pkg/config/hypervisor.go` — `KickstartConfig.Distro` accepts `ubuntu2404`.
+- 6 unit tests in `pkg/kickstart/ubuntu_iso_builder_test.go` covering GRUB
+  linux line injection, idempotency, isolinux append, linuxefi variant,
+  defaults, and missing-file rejection.
+
+Direct fix for the dbx-control deployment (infrastructure ADR-0109): VM 2900
+hung on Subiquity confirm because the legacy ubuntu2204 preseed builder
+couldn't generate a valid Subiquity-aware install ISO. Operator demand:
+"not good workaround, enhance kickstart auto install for ubuntu" — this
+ships the proper engineering fix.
+
+Workflow integration (single_vm dispatcher) lands in v2026.04.30.6+; this
+release ships the builder + templates + renderer wiring + tests.
+
 ## v2026.04.30.4 — 2026-04-30
 
 ### feat: replay + golden traces (#46)

--- a/pkg/config/hypervisor.go
+++ b/pkg/config/hypervisor.go
@@ -81,7 +81,7 @@ type ISOConfig struct {
 
 // KickstartConfig is the per-env kickstart/preseed inputs proxctl renders into a bootstrap file.
 type KickstartConfig struct {
-	Distro          string              `yaml:"distro"                     json:"distro"                     validate:"required,oneof=oraclelinux8 oraclelinux9 ubuntu2204 rhel9 rocky9 sles15"`
+	Distro          string              `yaml:"distro"                     json:"distro"                     validate:"required,oneof=oraclelinux8 oraclelinux9 ubuntu2204 ubuntu2404 rhel9 rocky9 sles15"`
 	Timezone        string              `yaml:"timezone,omitempty"         json:"timezone,omitempty"`
 	KeyboardLayout  string              `yaml:"keyboard_layout,omitempty"  json:"keyboard_layout,omitempty"`
 	Lang            string              `yaml:"lang,omitempty"             json:"lang,omitempty"`

--- a/pkg/kickstart/renderer.go
+++ b/pkg/kickstart/renderer.go
@@ -160,10 +160,11 @@ func (r *Renderer) Render(env *config.Env, nodeName string) (string, error) {
 		ctx.ScanIPs = cluster.ScanIPs
 	}
 
-	// Pick entry-point template. Prefer a template named "base.ks" then "preseed.cfg".
+	// Pick entry-point template. Prefer base.ks (RHEL/OEL kickstart) then preseed.cfg
+	// (Debian/Ubuntu legacy preseed) then user-data (Ubuntu 22.04+ Subiquity autoinstall).
 	entry := pickEntry(t)
 	if entry == "" {
-		return "", fmt.Errorf("distro %q: no entry template (expected base.ks.tmpl or preseed.cfg.tmpl)", distro)
+		return "", fmt.Errorf("distro %q: no entry template (expected base.ks.tmpl, preseed.cfg.tmpl, or user-data.tmpl)", distro)
 	}
 
 	var buf bytes.Buffer
@@ -175,7 +176,7 @@ func (r *Renderer) Render(env *config.Env, nodeName string) (string, error) {
 
 // pickEntry chooses the entry-point template name from the parsed set.
 func pickEntry(t *template.Template) string {
-	candidates := []string{"base.ks.tmpl", "preseed.cfg.tmpl", "base.ks", "preseed.cfg"}
+	candidates := []string{"base.ks.tmpl", "preseed.cfg.tmpl", "user-data.tmpl", "base.ks", "preseed.cfg", "user-data"}
 	for _, name := range candidates {
 		if t.Lookup(name) != nil {
 			return name

--- a/pkg/kickstart/templates/ubuntu2404/meta-data.tmpl
+++ b/pkg/kickstart/templates/ubuntu2404/meta-data.tmpl
@@ -1,0 +1,2 @@
+instance-id: {{ .Hostname }}-{{ now | date "2006-01-02T15-04-05Z" }}
+local-hostname: {{ .Hostname }}

--- a/pkg/kickstart/templates/ubuntu2404/user-data.tmpl
+++ b/pkg/kickstart/templates/ubuntu2404/user-data.tmpl
@@ -1,0 +1,114 @@
+#cloud-config
+# proxctl-generated Subiquity autoinstall for {{ .FQDN }}
+# Distro: {{ .Kickstart.Distro }}
+#
+# Ubuntu 22.04.5+ / 24.04+ server ISOs ship Subiquity (autoinstall via
+# cloud-init cidata) — no preseed support, no isolinux. proxctl builds
+# a cidata ISO containing this user-data + a meta-data file; Subiquity
+# auto-detects it as a second CD-ROM and runs autoinstall non-
+# interactively (interactive-sections: []).
+autoinstall:
+  version: 1
+  interactive-sections: []
+  locale: {{ if .Kickstart.Lang }}{{ .Kickstart.Lang }}{{ else }}en_US.UTF-8{{ end }}
+  keyboard:
+    layout: {{ if .Kickstart.KeyboardLayout }}{{ .Kickstart.KeyboardLayout }}{{ else }}us{{ end }}
+
+  identity:
+    hostname: {{ .Hostname }}
+{{- $primaryUser := "" }}
+{{- range $u := .Kickstart.AdditionalUsers }}
+{{- if eq $primaryUser "" }}
+{{- $primaryUser = $u.Name }}
+    realname: {{ $u.Name }}
+    username: {{ $u.Name }}
+    # Locked password — operator authenticates via SSH key.
+    password: '!locked!'
+{{- end }}
+{{- end }}
+{{- if eq $primaryUser "" }}
+    realname: ubuntu
+    username: ubuntu
+    password: '!locked!'
+{{- end }}
+
+  ssh:
+    install-server: true
+    allow-pw: false
+    authorized-keys:
+{{- range $u := .Kickstart.AdditionalUsers }}
+{{- if $u.SSHKey }}
+      - {{ $u.SSHKey | squote }}
+{{- end }}
+{{- end }}
+
+  network:
+    version: 2
+    ethernets:
+{{- range $i, $n := .Node.NICs }}
+{{- if $n.IPv4 }}
+      {{ $n.Name }}:
+        dhcp4: false
+        dhcp6: false
+        addresses: [{{ $n.IPv4.Address }}]
+{{- if $n.IPv4.Gateway }}
+        routes:
+          - to: default
+            via: {{ $n.IPv4.Gateway }}
+{{- end }}
+{{- if $n.IPv4.DNS }}
+        nameservers:
+          addresses: [{{ range $j, $d := $n.IPv4.DNS }}{{ if $j }}, {{ end }}{{ $d }}{{ end }}]
+{{- if $.Env.Metadata.Domain }}
+          search: [{{ $.Env.Metadata.Domain }}]
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+  storage:
+    layout:
+      name: lvm
+
+  packages:
+{{- if and .Kickstart.Packages .Kickstart.Packages.Base }}
+{{- range $p := .Kickstart.Packages.Base }}
+    - {{ $p }}
+{{- end }}
+{{- else }}
+    - chrony
+    - openssh-server
+    - qemu-guest-agent
+    - cifs-utils
+    - jq
+    - curl
+    - vim
+    - ca-certificates
+{{- end }}
+
+  late-commands:
+    # Root SSH key install
+    - 'curtin in-target -- mkdir -p /root/.ssh'
+    - 'curtin in-target -- chmod 700 /root/.ssh'
+{{- range $user, $keys := .Kickstart.SSHKeys }}
+{{- if eq $user "root" }}
+{{- range $k := $keys }}
+    - 'echo {{ $k | squote }} | curtin in-target -- tee -a /root/.ssh/authorized_keys'
+{{- end }}
+{{- end }}
+{{- end }}
+    - 'curtin in-target -- chmod 600 /root/.ssh/authorized_keys || true'
+    - 'curtin in-target -- sed -i "s/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/" /etc/ssh/sshd_config'
+    # sudo NOPASSWD for wheel-equivalent users
+{{- range $u := .Kickstart.AdditionalUsers }}
+{{- if $u.Wheel }}
+    - 'curtin in-target -- usermod -aG sudo {{ $u.Name }}'
+    - 'echo "{{ $u.Name }} ALL=(ALL) NOPASSWD: ALL" | curtin in-target -- tee /etc/sudoers.d/{{ $u.Name }}'
+    - 'curtin in-target -- chmod 0440 /etc/sudoers.d/{{ $u.Name }}'
+{{- end }}
+{{- end }}
+    # Enable services
+    - 'curtin in-target -- systemctl enable chrony qemu-guest-agent ssh'
+{{- if .Kickstart.UpdateSystem }}
+    - 'curtin in-target -- apt-get -y update && apt-get -y upgrade'
+{{- end }}

--- a/pkg/kickstart/ubuntu_iso_builder.go
+++ b/pkg/kickstart/ubuntu_iso_builder.go
@@ -1,0 +1,212 @@
+package kickstart
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// UbuntuISOBuilder remasters a Ubuntu 22.04+ live-server ISO to enable
+// fully unattended Subiquity autoinstall.
+//
+// Why a separate builder:
+//
+// Ubuntu 22.04.5+ live-server ISOs ship Subiquity (autoinstall via
+// cloud-init datasource) — no preseed, no isolinux. The legacy
+// ISOBuilder which builds a small bootable kickstart-only ISO doesn't
+// apply. Instead, autoinstall requires:
+//
+//  1. The install ISO itself, modified so its GRUB linux entries pass
+//     `autoinstall ds=nocloud\;s=/cidata/` on the kernel cmdline. Without
+//     this, Subiquity prompts the operator to confirm — defeating the
+//     purpose of automation.
+//  2. A `cidata` directory containing user-data + meta-data added to the
+//     ISO root. Subiquity reads it from the kernel-cmdline-specified path.
+//
+// Implementation:
+//
+//   - Use xorriso `-indev`/`-outdev` mode to repack without 3 GB of
+//     extraction overhead. xorriso preserves the original El Torito
+//     boot image (BIOS) + UEFI eltorito.img automatically with
+//     `-boot_image any replay`.
+//   - Inject `autoinstall ds=nocloud\;s=/cidata/` into every `linux`
+//     line of /boot/grub/grub.cfg + isolinux/txt.cfg if present.
+//   - Add the cidata files at /cidata/ so Subiquity finds them.
+//
+// Operator can override the install ISO via the env manifest's
+// `iso.image`; the original is read-only — we always write a new
+// ISO file alongside it.
+type UbuntuISOBuilder struct {
+	// SourceISOPath is the path to the unmodified Ubuntu install ISO.
+	SourceISOPath string
+	// CIDataDir is a directory containing user-data and meta-data files.
+	// Both must be non-empty cloud-init-format files.
+	CIDataDir string
+	// WorkDir for extraction + ISO repack scratch space.
+	WorkDir string
+	// AutoinstallKernelArgs is appended to GRUB linux lines.
+	// Default: "autoinstall ds=nocloud\\;s=/cidata/"
+	AutoinstallKernelArgs string
+}
+
+// NewUbuntuISOBuilder is the canonical constructor.
+func NewUbuntuISOBuilder(sourceISOPath, cidataDir string) *UbuntuISOBuilder {
+	return &UbuntuISOBuilder{
+		SourceISOPath:         sourceISOPath,
+		CIDataDir:             cidataDir,
+		AutoinstallKernelArgs: `autoinstall ds=nocloud\;s=/cidata/`,
+	}
+}
+
+// Build produces a remastered ISO with autoinstall enabled.
+// The returned path is in WorkDir (or os.TempDir if WorkDir is empty).
+// Caller is responsible for deleting the result + the source CIDataDir
+// after use.
+func (b *UbuntuISOBuilder) Build(hostname string) (string, error) {
+	if b.SourceISOPath == "" {
+		return "", fmt.Errorf("UbuntuISOBuilder: SourceISOPath is required")
+	}
+	if b.CIDataDir == "" {
+		return "", fmt.Errorf("UbuntuISOBuilder: CIDataDir is required")
+	}
+	if _, err := os.Stat(b.SourceISOPath); err != nil {
+		return "", fmt.Errorf("source ISO not found: %w", err)
+	}
+	for _, name := range []string{"user-data", "meta-data"} {
+		if _, err := os.Stat(filepath.Join(b.CIDataDir, name)); err != nil {
+			return "", fmt.Errorf("cidata dir missing %s: %w", name, err)
+		}
+	}
+	if _, err := exec.LookPath("xorriso"); err != nil {
+		return "", fmt.Errorf("xorriso not on PATH (Ubuntu ISO repack requires xorriso)")
+	}
+
+	workRoot := b.WorkDir
+	if workRoot == "" {
+		workRoot = os.TempDir()
+	}
+	scratch, err := os.MkdirTemp(workRoot, "proxctl-ubuntu-"+hostname+"-")
+	if err != nil {
+		return "", fmt.Errorf("mkdtemp: %w", err)
+	}
+	// Caller can defer-clean. We do NOT remove on success because the
+	// returned ISO lives in this dir.
+
+	// Extract grub.cfg + isolinux/txt.cfg (if present) so we can patch.
+	for _, p := range []string{"boot/grub/grub.cfg", "isolinux/txt.cfg"} {
+		if err := extractISOFile(b.SourceISOPath, p, filepath.Join(scratch, "orig-"+filepath.Base(p))); err != nil {
+			// Some ISOs have only grub (UEFI-only); txt.cfg may be absent.
+			// grub.cfg MUST exist for any modern Ubuntu live-server.
+			if p == "boot/grub/grub.cfg" {
+				return "", fmt.Errorf("extract %s: %w", p, err)
+			}
+		}
+	}
+
+	// Patch grub.cfg.
+	grubOrig := filepath.Join(scratch, "orig-grub.cfg")
+	grubNew := filepath.Join(scratch, "grub.cfg")
+	if err := patchKernelCmdline(grubOrig, grubNew, b.AutoinstallKernelArgs); err != nil {
+		return "", fmt.Errorf("patch grub.cfg: %w", err)
+	}
+
+	// Patch isolinux/txt.cfg if it exists.
+	txtOrig := filepath.Join(scratch, "orig-txt.cfg")
+	txtNew := filepath.Join(scratch, "txt.cfg")
+	hasIsolinux := false
+	if _, err := os.Stat(txtOrig); err == nil {
+		if err := patchKernelCmdline(txtOrig, txtNew, b.AutoinstallKernelArgs); err != nil {
+			return "", fmt.Errorf("patch isolinux/txt.cfg: %w", err)
+		}
+		hasIsolinux = true
+	}
+
+	// Build the remastered ISO via xorriso indev/outdev.
+	outPath := filepath.Join(scratch, fmt.Sprintf("%s_install_autoinstall.iso", hostname))
+	args := []string{
+		"-indev", b.SourceISOPath,
+		"-outdev", outPath,
+		"-boot_image", "any", "replay",
+		// Patch grub.cfg
+		"-map", grubNew, "/boot/grub/grub.cfg",
+		// Embed cidata files at /cidata/
+		"-map", filepath.Join(b.CIDataDir, "user-data"), "/cidata/user-data",
+		"-map", filepath.Join(b.CIDataDir, "meta-data"), "/cidata/meta-data",
+		// Joliet + Rock Ridge for cross-platform readability
+		"-joliet", "on",
+		"-rockridge", "on",
+	}
+	if hasIsolinux {
+		args = append(args[:len(args)-4],
+			append([]string{"-map", txtNew, "/isolinux/txt.cfg"}, args[len(args)-4:]...)...)
+	}
+
+	cmd := exec.Command("xorriso", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("xorriso repack failed: %w: %s", err, string(out))
+	}
+	return outPath, nil
+}
+
+// extractISOFile copies a single file from inside an ISO to dstPath
+// using xorriso. Used to read grub.cfg and txt.cfg for patching.
+func extractISOFile(isoPath, srcPath, dstPath string) error {
+	tmpDir, err := os.MkdirTemp("", "proxctl-extract-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cmd := exec.Command("xorriso", "-osirrox", "on", "-indev", isoPath,
+		"-extract", "/"+srcPath, filepath.Join(tmpDir, filepath.Base(srcPath)))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("xorriso extract: %w: %s", err, string(out))
+	}
+	in, err := os.Open(filepath.Join(tmpDir, filepath.Base(srcPath)))
+	if err != nil {
+		return fmt.Errorf("read extracted: %w", err)
+	}
+	defer in.Close()
+	out, err := os.Create(dstPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+// patchKernelCmdline rewrites lines beginning with `linux` (or `kernel`/`append`
+// for legacy isolinux) to append the supplied args, unless they're already
+// present. Idempotent: re-running on an already-patched config is a no-op.
+//
+// Match patterns:
+//   - GRUB:     `linux ... <args>`
+//   - isolinux: `append ... <args>` (used after `kernel <path>`)
+func patchKernelCmdline(srcPath, dstPath, autoinstallArgs string) error {
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(data), "\n")
+	// Match the leading verb (linux | linuxefi | append) at the start of a
+	// trimmed line. We preserve original indentation via a capture group.
+	re := regexp.MustCompile(`^(\s*)(linux|linuxefi|append)\s+(.*)$`)
+	for i, line := range lines {
+		m := re.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		body := m[3]
+		if strings.Contains(body, "autoinstall") {
+			// Already patched; leave alone.
+			continue
+		}
+		lines[i] = m[1] + m[2] + " " + body + " " + autoinstallArgs
+	}
+	return os.WriteFile(dstPath, []byte(strings.Join(lines, "\n")), 0o644)
+}

--- a/pkg/kickstart/ubuntu_iso_builder_test.go
+++ b/pkg/kickstart/ubuntu_iso_builder_test.go
@@ -1,0 +1,115 @@
+package kickstart
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPatchKernelCmdline_GrubLinuxLine(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "grub-orig.cfg")
+	dst := filepath.Join(dir, "grub-new.cfg")
+	in := `set timeout=30
+menuentry "Try or Install Ubuntu Server" {
+    set gfxpayload=keep
+    linux   /casper/vmlinuz   ---
+    initrd  /casper/initrd
+}`
+	if err := os.WriteFile(src, []byte(in), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cidata/`); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(dst)
+	if !strings.Contains(string(got), `autoinstall ds=nocloud\;s=/cidata/`) {
+		t.Errorf("autoinstall args not injected:\n%s", got)
+	}
+	if !strings.Contains(string(got), `/casper/vmlinuz`) || !strings.Contains(string(got), `---`) {
+		t.Errorf("original linux line content lost:\n%s", got)
+	}
+}
+
+func TestPatchKernelCmdline_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.cfg")
+	dst := filepath.Join(dir, "dst.cfg")
+	already := "linux /casper/vmlinuz --- autoinstall ds=nocloud\\;s=/cidata/\n"
+	os.WriteFile(src, []byte(already), 0o644)
+	patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cidata/`)
+	got, _ := os.ReadFile(dst)
+	// Should NOT have appended a second copy of autoinstall.
+	if strings.Count(string(got), "autoinstall") != 1 {
+		t.Errorf("idempotency broken — autoinstall appears %d times:\n%s",
+			strings.Count(string(got), "autoinstall"), got)
+	}
+}
+
+func TestPatchKernelCmdline_IsolinuxAppend(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "txt.cfg")
+	dst := filepath.Join(dir, "txt-new.cfg")
+	in := `default install
+label install
+  menu label ^Install Ubuntu Server
+  kernel /casper/vmlinuz
+  append initrd=/casper/initrd quiet ---
+`
+	os.WriteFile(src, []byte(in), 0o644)
+	patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cidata/`)
+	got, _ := os.ReadFile(dst)
+	if !strings.Contains(string(got), `autoinstall ds=nocloud\;s=/cidata/`) {
+		t.Errorf("autoinstall not appended to isolinux append line:\n%s", got)
+	}
+	// kernel line untouched (we only patch append/linux/linuxefi).
+	if !strings.Contains(string(got), "kernel /casper/vmlinuz\n") {
+		t.Errorf("kernel line should be untouched:\n%s", got)
+	}
+}
+
+func TestPatchKernelCmdline_LinuxefiVariant(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "grub.cfg")
+	dst := filepath.Join(dir, "grub-new.cfg")
+	in := `menuentry "Install" {
+    linuxefi /casper/vmlinuz quiet
+    initrdefi /casper/initrd
+}`
+	os.WriteFile(src, []byte(in), 0o644)
+	patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cidata/`)
+	got, _ := os.ReadFile(dst)
+	if !strings.Contains(string(got), `linuxefi /casper/vmlinuz quiet autoinstall ds=nocloud\;s=/cidata/`) {
+		t.Errorf("linuxefi variant not patched:\n%s", got)
+	}
+}
+
+func TestNewUbuntuISOBuilder_Defaults(t *testing.T) {
+	b := NewUbuntuISOBuilder("/tmp/foo.iso", "/tmp/cidata")
+	if b.AutoinstallKernelArgs != `autoinstall ds=nocloud\;s=/cidata/` {
+		t.Errorf("default autoinstall args: %q", b.AutoinstallKernelArgs)
+	}
+}
+
+func TestUbuntuISOBuilder_RejectsMissingFiles(t *testing.T) {
+	dir := t.TempDir()
+	cidata := filepath.Join(dir, "cidata")
+	os.MkdirAll(cidata, 0o755)
+
+	b := &UbuntuISOBuilder{
+		SourceISOPath: "/nonexistent/foo.iso",
+		CIDataDir:     cidata,
+	}
+	if _, err := b.Build("test"); err == nil {
+		t.Error("expected error for missing source ISO")
+	}
+
+	// cidata missing user-data
+	iso := filepath.Join(dir, "fake.iso")
+	os.WriteFile(iso, []byte("fake"), 0o644)
+	b.SourceISOPath = iso
+	if _, err := b.Build("test"); err == nil {
+		t.Error("expected error for missing user-data")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `ubuntu2404` distro template + xorriso-based ISO repack builder for Subiquity autoinstall
- Patches GRUB `linux`/`linuxefi` and isolinux `append` lines with `autoinstall ds=nocloud\;s=/cidata/`
- Embeds rendered `user-data` + `meta-data` at `/cidata/` in the install ISO
- Distro-aware Wheel→sudo mapping (Ubuntu has no `wheel` group)
- 6 unit tests; full proxctl test suite green

Direct fix for `infrastructure` dbx-control deployment (ADR-0109): VM 2900 hung on Subiquity confirm because the legacy `ubuntu2204` preseed builder couldn't drive Ubuntu 22.04.5+/24.04 live-server. Operator demand: *"not good workaround, enhance kickstart auto install for ubuntu"* — this ships the proper engineering fix.

Closes #48.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] `go test ./pkg/kickstart/... -run 'PatchKernel|Ubuntu'` — 6 ubuntu2404 tests pass
- [ ] Live test: rebuild ISO + boot VM 2900 unattended (post-merge, v2026.04.30.6+ once workflow dispatcher wired)

## Follow-ups

- v2026.04.30.6: wire `UbuntuISOBuilder` into the SingleVM workflow dispatcher so `proxctl-stack-kickstart` automatically picks it for `distro: ubuntu2404`.
- linuxctl mirror — none needed (linuxctl is post-install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)