### PR TITLE
feat(kickstart): build-ubuntu CLI + macaddress NIC match (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.30.6 — 2026-04-30
+
+### feat: `proxctl kickstart build-ubuntu` CLI + macaddress NIC matching
+
+- `proxctl kickstart build-ubuntu --env <env.yaml> --node <name> --source-iso <path>`
+  drives the v2026.04.30.5 `UbuntuISOBuilder` end-to-end: renders
+  `user-data.tmpl` + `meta-data.tmpl` from the env manifest, writes them to a
+  scratch cidata dir, calls the builder to produce a remastered Ubuntu install
+  ISO with autoinstall in GRUB + cidata at `/cidata/`. Operator uploads the
+  result via `proxctl kickstart upload`.
+- `Renderer.RenderTemplate(env, nodeName, templateName)` — new public method
+  for the multi-file Subiquity flow (Render() picks a single entry point;
+  Subiquity needs both user-data + meta-data rendered separately).
+- `pkg/kickstart/templates/ubuntu2404/user-data.tmpl` — netplan ethernet match
+  is now `macaddress` (when manifest has a real MAC) with fallback to
+  `name: "en*"` (when MAC is `auto` or empty), plus `set-name` to rename the
+  matched interface back to the manifest-declared logical name. Fixes a class
+  of failures where Ubuntu 24.04 names virtio NICs `enp6s18` on q35 vs
+  `ens18` on i440fx — static names don't survive bus changes.
+
+Workflow dispatcher integration (`SingleVMWorkflow` auto-routes ubuntu2404 to
+the new builder + uploads the remastered ISO as the install ISO instead of
+the upstream one) ships in v2026.04.30.7. For now operators using
+`distro: ubuntu2404` build the ISO out-of-band via the new CLI, upload it,
+and run `proxctl-stack-up --skip-kickstart-build` (or equivalent) against a
+manifest that points `iso.image` at the remastered ISO.
+
 ## v2026.04.30.5 — 2026-04-30
 
 ### feat: ubuntu2404 Subiquity autoinstall via cidata + GRUB cmdline injection

--- a/internal/root/kickstart.go
+++ b/internal/root/kickstart.go
@@ -23,6 +23,10 @@ func newKickstartCmd() *cobra.Command {
 	var buildBootloader string
 	var uploadStorage string
 	var uploadNode string
+	var ubuntuNode string
+	var ubuntuSourceISO string
+	var ubuntuOut string
+	var ubuntuWorkDir string
 
 	c.AddCommand(
 		func() *cobra.Command {
@@ -129,6 +133,80 @@ func newKickstartCmd() *cobra.Command {
 			}
 			cc.Flags().StringVar(&uploadStorage, "storage", "", "PVE storage name")
 			cc.Flags().StringVar(&uploadNode, "node", "", "PVE node name")
+			return cc
+		}(),
+		func() *cobra.Command {
+			cc := &cobra.Command{
+				Use:   "build-ubuntu [ENV_FILE]",
+				Short: "Build Ubuntu 22.04+ Subiquity autoinstall ISO (cidata + GRUB cmdline injection)",
+				Long: `Renders user-data + meta-data from the env manifest, embeds them at /cidata/
+in a remastered copy of the upstream Ubuntu live-server install ISO, and
+patches the GRUB linux/linuxefi/isolinux append lines to add
+` + "`autoinstall ds=nocloud\\;s=/cidata/`" + ` to the kernel cmdline. The
+result is a standalone ISO that boots Ubuntu unattended via Subiquity.
+
+Use this when env.spec.hypervisor.kickstart.distro = "ubuntu2404".`,
+				Args: cobra.MaximumNArgs(1),
+				RunE: func(cmd *cobra.Command, args []string) error {
+					if ubuntuSourceISO == "" {
+						return fmt.Errorf("--source-iso required (path to upstream Ubuntu live-server ISO)")
+					}
+					if ubuntuNode == "" {
+						return fmt.Errorf("--node required")
+					}
+					var envPath string
+					if len(args) > 0 {
+						envPath = args[0]
+					}
+					env, err := loadEnvManifest(envPath)
+					if err != nil {
+						return err
+					}
+					rnd, err := kickstart.NewRenderer()
+					if err != nil {
+						return err
+					}
+					userData, err := rnd.RenderTemplate(env, ubuntuNode, "user-data.tmpl")
+					if err != nil {
+						return fmt.Errorf("render user-data: %w", err)
+					}
+					metaData, err := rnd.RenderTemplate(env, ubuntuNode, "meta-data.tmpl")
+					if err != nil {
+						return fmt.Errorf("render meta-data: %w", err)
+					}
+					cidataDir, err := os.MkdirTemp("", "proxctl-ubuntu-cidata-")
+					if err != nil {
+						return err
+					}
+					defer os.RemoveAll(cidataDir)
+					if err := os.WriteFile(filepath.Join(cidataDir, "user-data"), []byte(userData), 0o644); err != nil {
+						return err
+					}
+					if err := os.WriteFile(filepath.Join(cidataDir, "meta-data"), []byte(metaData), 0o644); err != nil {
+						return err
+					}
+					b := kickstart.NewUbuntuISOBuilder(ubuntuSourceISO, cidataDir)
+					if ubuntuWorkDir != "" {
+						b.WorkDir = ubuntuWorkDir
+					}
+					path, err := b.Build(ubuntuNode)
+					if err != nil {
+						return err
+					}
+					if ubuntuOut != "" && ubuntuOut != path {
+						if err := os.Rename(path, ubuntuOut); err != nil {
+							return err
+						}
+						path = ubuntuOut
+					}
+					fmt.Println(path)
+					return nil
+				},
+			}
+			cc.Flags().StringVar(&ubuntuNode, "node", "", "Node name from hypervisor.nodes (used as hostname)")
+			cc.Flags().StringVar(&ubuntuSourceISO, "source-iso", "", "Path to upstream Ubuntu live-server install ISO")
+			cc.Flags().StringVarP(&ubuntuOut, "out", "o", "", "Output ISO path (default: tempdir under workdir)")
+			cc.Flags().StringVar(&ubuntuWorkDir, "workdir", "", "Scratch directory (default: $TMPDIR)")
 			return cc
 		}(),
 		&cobra.Command{

--- a/pkg/kickstart/renderer.go
+++ b/pkg/kickstart/renderer.go
@@ -100,6 +100,73 @@ func (r *Renderer) SupportedDistros() []string {
 	return out
 }
 
+// RenderTemplate executes a specific template by name (e.g. "user-data.tmpl",
+// "meta-data.tmpl") for nodeName. Used by Ubuntu Subiquity flows that need
+// to render multiple cidata files separately, in contrast to the single-
+// entry-point Render path used for kickstart/preseed.
+func (r *Renderer) RenderTemplate(env *config.Env, nodeName, templateName string) (string, error) {
+	if env == nil {
+		return "", fmt.Errorf("env is nil")
+	}
+	hyp := env.Spec.Hypervisor.Resolved()
+	if hyp == nil {
+		return "", fmt.Errorf("env.spec.hypervisor not resolved")
+	}
+	node, ok := hyp.Nodes[nodeName]
+	if !ok {
+		return "", fmt.Errorf("node %q not found in hypervisor.nodes", nodeName)
+	}
+	if hyp.Kickstart == nil {
+		return "", fmt.Errorf("env has no kickstart config")
+	}
+	ks := hyp.Kickstart
+	distro := ks.Distro
+	t, ok := r.entries[distro]
+	if !ok {
+		return "", fmt.Errorf("unsupported distro %q (supported: %v)", distro, r.distros)
+	}
+	if t.Lookup(templateName) == nil {
+		return "", fmt.Errorf("distro %q has no template %q", distro, templateName)
+	}
+
+	nets := map[string]config.NetworkZone{}
+	if env.Spec.Networks.Resolved() != nil {
+		nets = env.Spec.Networks.Resolved().Zones
+	}
+	var cluster *config.Cluster
+	if env.Spec.Cluster != nil {
+		cluster = env.Spec.Cluster.Resolved()
+	}
+	hostname := nodeName
+	domain := env.Metadata.Domain
+	fqdn := hostname
+	if domain != "" {
+		fqdn = hostname + "." + domain
+	}
+	ctx := RenderContext{
+		Env:       env,
+		Node:      &node,
+		NodeName:  nodeName,
+		Hostname:  hostname,
+		FQDN:      fqdn,
+		Kickstart: ks,
+		Networks:  nets,
+		Cluster:   cluster,
+		PublicIP:  node.IPs["public"],
+		VIPIP:     node.IPs["vip"],
+		PrivateIP: node.IPs["private"],
+	}
+	if cluster != nil {
+		ctx.ScanIPs = cluster.ScanIPs
+	}
+
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, templateName, ctx); err != nil {
+		return "", fmt.Errorf("execute %s/%s: %w", distro, templateName, err)
+	}
+	return buf.String(), nil
+}
+
 // Render generates a kickstart file for nodeName using env's hypervisor/kickstart data.
 func (r *Renderer) Render(env *config.Env, nodeName string) (string, error) {
 	if env == nil {

--- a/pkg/kickstart/templates/ubuntu2404/user-data.tmpl
+++ b/pkg/kickstart/templates/ubuntu2404/user-data.tmpl
@@ -44,10 +44,20 @@ autoinstall:
 
   network:
     version: 2
+    # Match by MAC address — Ubuntu 24.04 names virtio NICs `enp6s18` on q35
+    # vs `ens18` on i440fx, so static names are non-portable. set-name renames
+    # back to the manifest-declared logical name for stability.
     ethernets:
 {{- range $i, $n := .Node.NICs }}
 {{- if $n.IPv4 }}
       {{ $n.Name }}:
+        match:
+{{- if and $n.MAC (ne $n.MAC "auto") }}
+          macaddress: {{ $n.MAC | lower }}
+{{- else }}
+          name: "en*"
+{{- end }}
+        set-name: {{ $n.Name }}
         dhcp4: false
         dhcp6: false
         addresses: [{{ $n.IPv4.Address }}]


### PR DESCRIPTION
Operator CLI driving v2026.04.30.5 UbuntuISOBuilder + netplan NIC match fix. See CHANGELOG for v2026.04.30.6. Closes #50.