### PR TITLE
fix(kickstart): ubuntu2404 autoinstall must inject BEFORE casper --- separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.04.30.7 — 2026-04-30
+
+### fix: ubuntu2404 autoinstall must inject BEFORE casper `---` separator
+
+v2026.04.30.5/6 patched the GRUB linux line by appending the autoinstall
+args at the end. Caught during the dbx-control live deployment: that placed
+`autoinstall` AFTER `---`, where casper reserves args for the post-install
+kernel and the live boot's Subiquity does NOT see them. Result: Subiquity
+defaulted to interactive mode and prompted the operator to confirm —
+exactly the failure mode the patch was meant to eliminate.
+
+This release:
+
+- `pkg/kickstart/ubuntu_iso_builder.go` — `patchKernelCmdline` now uses
+  `injectBeforeSeparator()` which inserts immediately before the casper
+  `---` separator (or appends if no separator exists).
+- Default `AutoinstallKernelArgs` updated to `s=/cdrom/cidata/` (live
+  system mounts the install ISO at `/cdrom`, not `/`).
+- New unit test `TestPatchKernelCmdline_InjectsBeforeCasperSeparator`
+  asserting `autoinstall` index < `---` index.
+- Existing tests updated for the new path + injection position.
+
+Direct fix for VM 2900 / dbx-control deployment (infrastructure ADR-0109).
+
 ## v2026.04.30.6 — 2026-04-30
 
 ### feat: `proxctl kickstart build-ubuntu` CLI + macaddress NIC matching

--- a/pkg/kickstart/ubuntu_iso_builder.go
+++ b/pkg/kickstart/ubuntu_iso_builder.go
@@ -21,7 +21,7 @@ import (
 // apply. Instead, autoinstall requires:
 //
 //  1. The install ISO itself, modified so its GRUB linux entries pass
-//     `autoinstall ds=nocloud\;s=/cidata/` on the kernel cmdline. Without
+//     `autoinstall ds=nocloud\;s=/cdrom/cidata/` on the kernel cmdline. Without
 //     this, Subiquity prompts the operator to confirm — defeating the
 //     purpose of automation.
 //  2. A `cidata` directory containing user-data + meta-data added to the
@@ -33,7 +33,7 @@ import (
 //     extraction overhead. xorriso preserves the original El Torito
 //     boot image (BIOS) + UEFI eltorito.img automatically with
 //     `-boot_image any replay`.
-//   - Inject `autoinstall ds=nocloud\;s=/cidata/` into every `linux`
+//   - Inject `autoinstall ds=nocloud\;s=/cdrom/cidata/` into every `linux`
 //     line of /boot/grub/grub.cfg + isolinux/txt.cfg if present.
 //   - Add the cidata files at /cidata/ so Subiquity finds them.
 //
@@ -58,7 +58,7 @@ func NewUbuntuISOBuilder(sourceISOPath, cidataDir string) *UbuntuISOBuilder {
 	return &UbuntuISOBuilder{
 		SourceISOPath:         sourceISOPath,
 		CIDataDir:             cidataDir,
-		AutoinstallKernelArgs: `autoinstall ds=nocloud\;s=/cidata/`,
+		AutoinstallKernelArgs: `autoinstall ds=nocloud\;s=/cdrom/cidata/`,
 	}
 }
 
@@ -181,12 +181,21 @@ func extractISOFile(isoPath, srcPath, dstPath string) error {
 }
 
 // patchKernelCmdline rewrites lines beginning with `linux` (or `kernel`/`append`
-// for legacy isolinux) to append the supplied args, unless they're already
-// present. Idempotent: re-running on an already-patched config is a no-op.
+// for legacy isolinux) to inject the supplied autoinstall args, unless they're
+// already present. Idempotent: re-running on an already-patched config is a
+// no-op.
+//
+// Critical detail: in Ubuntu casper boot, `---` on the linux line separates
+// arguments seen by the live boot kernel (BEFORE `---`) from arguments
+// reserved for the post-install kernel (AFTER `---`). Subiquity reads
+// `/proc/cmdline` of the live boot, so `autoinstall` MUST appear BEFORE
+// `---` to take effect — otherwise Subiquity defaults to interactive mode
+// and prompts the operator to confirm. We insert immediately before the
+// `---` separator when present, else append.
 //
 // Match patterns:
-//   - GRUB:     `linux ... <args>`
-//   - isolinux: `append ... <args>` (used after `kernel <path>`)
+//   - GRUB:     `linux ... [---] <args>`
+//   - isolinux: `append ... [---] <args>`
 func patchKernelCmdline(srcPath, dstPath, autoinstallArgs string) error {
 	data, err := os.ReadFile(srcPath)
 	if err != nil {
@@ -194,7 +203,7 @@ func patchKernelCmdline(srcPath, dstPath, autoinstallArgs string) error {
 	}
 	lines := strings.Split(string(data), "\n")
 	// Match the leading verb (linux | linuxefi | append) at the start of a
-	// trimmed line. We preserve original indentation via a capture group.
+	// trimmed line. Preserve original indentation via a capture group.
 	re := regexp.MustCompile(`^(\s*)(linux|linuxefi|append)\s+(.*)$`)
 	for i, line := range lines {
 		m := re.FindStringSubmatch(line)
@@ -203,10 +212,25 @@ func patchKernelCmdline(srcPath, dstPath, autoinstallArgs string) error {
 		}
 		body := m[3]
 		if strings.Contains(body, "autoinstall") {
-			// Already patched; leave alone.
+			// Already patched.
 			continue
 		}
-		lines[i] = m[1] + m[2] + " " + body + " " + autoinstallArgs
+		newBody := injectBeforeSeparator(body, autoinstallArgs)
+		lines[i] = m[1] + m[2] + " " + newBody
 	}
 	return os.WriteFile(dstPath, []byte(strings.Join(lines, "\n")), 0o644)
+}
+
+// injectBeforeSeparator inserts args immediately before the casper `---`
+// separator if present; otherwise appends to the end.
+func injectBeforeSeparator(body, args string) string {
+	// Look for `---` as a standalone token (surrounded by whitespace, or at
+	// end of line). Use a regex anchored on word boundaries via spaces.
+	sepRE := regexp.MustCompile(`(\s)---(\s|$)`)
+	if loc := sepRE.FindStringIndex(body); loc != nil {
+		// Insert args before the matched `(\s)---`. loc[0] is the leading
+		// whitespace; insert just after it but before the `---`.
+		return body[:loc[0]] + " " + args + body[loc[0]:]
+	}
+	return body + " " + args
 }

--- a/pkg/kickstart/ubuntu_iso_builder_test.go
+++ b/pkg/kickstart/ubuntu_iso_builder_test.go
@@ -20,11 +20,11 @@ menuentry "Try or Install Ubuntu Server" {
 	if err := os.WriteFile(src, []byte(in), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cidata/`); err != nil {
+	if err := patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cdrom/cidata/`); err != nil {
 		t.Fatal(err)
 	}
 	got, _ := os.ReadFile(dst)
-	if !strings.Contains(string(got), `autoinstall ds=nocloud\;s=/cidata/`) {
+	if !strings.Contains(string(got), `autoinstall ds=nocloud\;s=/cdrom/cidata/`) {
 		t.Errorf("autoinstall args not injected:\n%s", got)
 	}
 	if !strings.Contains(string(got), `/casper/vmlinuz`) || !strings.Contains(string(got), `---`) {
@@ -36,9 +36,9 @@ func TestPatchKernelCmdline_Idempotent(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src.cfg")
 	dst := filepath.Join(dir, "dst.cfg")
-	already := "linux /casper/vmlinuz --- autoinstall ds=nocloud\\;s=/cidata/\n"
+	already := "linux /casper/vmlinuz autoinstall ds=nocloud\\;s=/cdrom/cidata/ ---\n"
 	os.WriteFile(src, []byte(already), 0o644)
-	patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cidata/`)
+	patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cdrom/cidata/`)
 	got, _ := os.ReadFile(dst)
 	// Should NOT have appended a second copy of autoinstall.
 	if strings.Count(string(got), "autoinstall") != 1 {
@@ -58,14 +58,33 @@ label install
   append initrd=/casper/initrd quiet ---
 `
 	os.WriteFile(src, []byte(in), 0o644)
-	patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cidata/`)
+	patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cdrom/cidata/`)
 	got, _ := os.ReadFile(dst)
-	if !strings.Contains(string(got), `autoinstall ds=nocloud\;s=/cidata/`) {
+	if !strings.Contains(string(got), `autoinstall ds=nocloud\;s=/cdrom/cidata/`) {
 		t.Errorf("autoinstall not appended to isolinux append line:\n%s", got)
 	}
 	// kernel line untouched (we only patch append/linux/linuxefi).
 	if !strings.Contains(string(got), "kernel /casper/vmlinuz\n") {
 		t.Errorf("kernel line should be untouched:\n%s", got)
+	}
+}
+
+func TestPatchKernelCmdline_InjectsBeforeCasperSeparator(t *testing.T) {
+	// Critical: in casper boot, args AFTER `---` are reserved for the
+	// post-install kernel and NOT seen by Subiquity in the live boot.
+	// `autoinstall` MUST appear BEFORE `---`.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "grub.cfg")
+	dst := filepath.Join(dir, "grub-new.cfg")
+	in := "menuentry \"Install\" {\n    linux /casper/vmlinuz quiet --- foo bar\n}\n"
+	os.WriteFile(src, []byte(in), 0o644)
+	patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cdrom/cidata/`)
+	got, _ := os.ReadFile(dst)
+	gotS := string(got)
+	autoIdx := strings.Index(gotS, "autoinstall")
+	sepIdx := strings.Index(gotS, "---")
+	if autoIdx < 0 || sepIdx < 0 || autoIdx > sepIdx {
+		t.Errorf("autoinstall must appear BEFORE casper `---` separator:\n%s", gotS)
 	}
 }
 
@@ -78,16 +97,16 @@ func TestPatchKernelCmdline_LinuxefiVariant(t *testing.T) {
     initrdefi /casper/initrd
 }`
 	os.WriteFile(src, []byte(in), 0o644)
-	patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cidata/`)
+	patchKernelCmdline(src, dst, `autoinstall ds=nocloud\;s=/cdrom/cidata/`)
 	got, _ := os.ReadFile(dst)
-	if !strings.Contains(string(got), `linuxefi /casper/vmlinuz quiet autoinstall ds=nocloud\;s=/cidata/`) {
+	if !strings.Contains(string(got), `linuxefi /casper/vmlinuz quiet autoinstall ds=nocloud\;s=/cdrom/cidata/`) {
 		t.Errorf("linuxefi variant not patched:\n%s", got)
 	}
 }
 
 func TestNewUbuntuISOBuilder_Defaults(t *testing.T) {
 	b := NewUbuntuISOBuilder("/tmp/foo.iso", "/tmp/cidata")
-	if b.AutoinstallKernelArgs != `autoinstall ds=nocloud\;s=/cidata/` {
+	if b.AutoinstallKernelArgs != `autoinstall ds=nocloud\;s=/cdrom/cidata/` {
 		t.Errorf("default autoinstall args: %q", b.AutoinstallKernelArgs)
 	}
 }


### PR DESCRIPTION
Live-deployment fix. v2026.04.30.5/6 appended autoinstall args at the END of the linux line, which placed them AFTER casper's `---` separator. casper reserves post-`---` args for the post-install kernel, so the live boot's Subiquity does NOT see them and defaults to interactive mode. Caught on VM 2900 (dbx-control). See CHANGELOG. Closes #52.