### PR TITLE
feat(kickstart): build-stack subcommand for OL8/9 (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.05.04.1 — 2026-05-04
+
+### feat: `proxctl kickstart build-stack` integrated OL8/OL9 build path (#56)
+
+Adds an integrated build path for Oracle Linux 8/9 (and other RHEL-family)
+distros, mirroring the shape of `build-ubuntu`. Unblocks the infrastructure
+repo's `/proxctl-stack-kickstart` skill which was calling a high-level
+per-stack iteration that did not exist in the binary.
+
+What's new:
+
+- `pkg/kickstart/iso_extractor.go` — `ExtractBootloader(sourceISO, destDir)`
+  uses `xorriso -osirrox` to pull `/isolinux/{isolinux.bin,ldlinux.c32,
+  vmlinuz,initrd.img}` from an upstream OL/RHEL/Rocky install ISO. Verifies
+  all four files post-extraction.
+- `internal/root/kickstart.go` — `proxctl kickstart build-stack [ENV_FILE]`
+  subcommand:
+  - extracts the bootloader once into a temp dir, reused for all nodes;
+  - rejects `ubuntu*` distros with a hint to use `build-ubuntu`;
+  - per-node renders ks.cfg → builds ISO → optional upload via mcp-proxmox
+    `UploadISO` to `hypervisor.iso.kickstart_storage`;
+  - flags: `--source-iso` (required), `--node`, `--out-dir`, `--upload`,
+    `--keep`.
+- `pkg/kickstart/iso_extractor_test.go` — unit tests for the extractor
+  (validation errors + happy path + missing-file detection). Skipped when
+  xorriso is not on PATH.
+- `internal/root/coverage_test.go` — smoke tests for `build-stack`
+  (`--source-iso` required, ubuntu rejection).
+
 ## v2026.04.30.7 — 2026-04-30
 
 ### fix: ubuntu2404 autoinstall must inject BEFORE casper `---` separator

--- a/internal/root/coverage_test.go
+++ b/internal/root/coverage_test.go
@@ -1571,3 +1571,47 @@ func TestNotImplemented_Fn(t *testing.T) {
 
 // ensure fmt is used (builds clean even if some tests above don't need it).
 var _ = fmt.Sprintf
+
+// TestKickstart_BuildStack_RequiresSourceISO covers the synchronous flag check.
+func TestKickstart_BuildStack_RequiresSourceISO(t *testing.T) {
+	home := isolateHome(t)
+	writeEnvFixture(t, home)
+	t.Chdir(home)
+	_, err := executeCmd(t, "kickstart", "build-stack")
+	if err == nil {
+		t.Fatal("expected error when --source-iso is missing")
+	}
+	if !strings.Contains(err.Error(), "source-iso") {
+		t.Fatalf("expected --source-iso error, got: %v", err)
+	}
+}
+
+// TestKickstart_BuildStack_RejectsUbuntu ensures the command refuses to run
+// for Ubuntu distros and points operators at build-ubuntu.
+func TestKickstart_BuildStack_RejectsUbuntu(t *testing.T) {
+	home := isolateHome(t)
+	writeEnvFixture(t, home)
+	t.Chdir(home)
+	// Patch the env fixture to be ubuntu2404. distro lives inline in env.yaml.
+	envPath := filepath.Join(home, "env.yaml")
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read env.yaml: %v", err)
+	}
+	patched := strings.ReplaceAll(string(data), "oraclelinux9", "ubuntu2404")
+	patched = strings.ReplaceAll(patched, "oraclelinux8", "ubuntu2404")
+	if err := os.WriteFile(envPath, []byte(patched), 0o644); err != nil {
+		t.Fatalf("write patched env: %v", err)
+	}
+
+	// Provide a fake source ISO path so we get past the source-iso check
+	// and into the distro check. The file doesn't need to exist — the
+	// distro check runs before extraction.
+	_, err = executeCmd(t, "kickstart", "build-stack", "--source-iso", "/tmp/fake.iso")
+	if err == nil {
+		t.Fatal("expected error for ubuntu distro")
+	}
+	if !strings.Contains(err.Error(), "build-ubuntu") {
+		t.Fatalf("expected hint to use build-ubuntu, got: %v", err)
+	}
+}

--- a/internal/root/kickstart.go
+++ b/internal/root/kickstart.go
@@ -3,13 +3,33 @@ package root
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/itunified-io/proxctl/pkg/kickstart"
+	"github.com/itunified-io/proxctl/pkg/proxmox"
 	"github.com/spf13/cobra"
 )
+
+// copyISOFile is a tiny helper for cross-device os.Rename fallback in build-stack.
+func copyISOFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}
 
 func newKickstartCmd() *cobra.Command {
 	c := &cobra.Command{
@@ -27,6 +47,12 @@ func newKickstartCmd() *cobra.Command {
 	var ubuntuSourceISO string
 	var ubuntuOut string
 	var ubuntuWorkDir string
+
+	var stackNode string
+	var stackSourceISO string
+	var stackOutDir string
+	var stackUpload bool
+	var stackKeep bool
 
 	c.AddCommand(
 		func() *cobra.Command {
@@ -207,6 +233,152 @@ Use this when env.spec.hypervisor.kickstart.distro = "ubuntu2404".`,
 			cc.Flags().StringVar(&ubuntuSourceISO, "source-iso", "", "Path to upstream Ubuntu live-server install ISO")
 			cc.Flags().StringVarP(&ubuntuOut, "out", "o", "", "Output ISO path (default: tempdir under workdir)")
 			cc.Flags().StringVar(&ubuntuWorkDir, "workdir", "", "Scratch directory (default: $TMPDIR)")
+			return cc
+		}(),
+		func() *cobra.Command {
+			cc := &cobra.Command{
+				Use:   "build-stack [ENV_FILE]",
+				Short: "Build per-node OL8/OL9 install ISOs from a stack manifest (integrated render+extract+build+upload)",
+				Long: `Mirrors build-ubuntu for OL8/OL9 (and other RHEL-family) distros: extracts
+the bootloader (isolinux.bin, ldlinux.c32, vmlinuz, initrd.img) from the
+upstream install ISO once, then for each node renders ks.cfg, builds a
+kickstart-only boot ISO, and optionally uploads it to the node's
+hypervisor.iso.kickstart_storage.
+
+Errors out for ubuntu* distros — use ` + "`build-ubuntu`" + ` instead.`,
+				Args: cobra.MaximumNArgs(1),
+				RunE: func(cmd *cobra.Command, args []string) error {
+					if stackSourceISO == "" {
+						return fmt.Errorf("--source-iso required (path to upstream OL install ISO)")
+					}
+					var envPath string
+					if len(args) > 0 {
+						envPath = args[0]
+					}
+					env, err := loadEnvManifest(envPath)
+					if err != nil {
+						return err
+					}
+					hyp := env.Spec.Hypervisor.Resolved()
+					if hyp == nil {
+						return fmt.Errorf("env.spec.hypervisor not resolved")
+					}
+					if hyp.Kickstart == nil {
+						return fmt.Errorf("env has no kickstart config")
+					}
+					distro := hyp.Kickstart.Distro
+					if strings.HasPrefix(distro, "ubuntu") {
+						return fmt.Errorf("distro %q is Ubuntu-family — use `proxctl kickstart build-ubuntu` instead", distro)
+					}
+
+					// Pick nodes.
+					var nodes []string
+					if stackNode != "" {
+						if _, ok := hyp.Nodes[stackNode]; !ok {
+							return fmt.Errorf("node %q not found in hypervisor.nodes", stackNode)
+						}
+						nodes = []string{stackNode}
+					} else {
+						for n := range hyp.Nodes {
+							nodes = append(nodes, n)
+						}
+					}
+					if len(nodes) == 0 {
+						return fmt.Errorf("no nodes to build")
+					}
+
+					// Extract bootloader once.
+					bootloaderDir, err := os.MkdirTemp("", "proxctl-bootloader-")
+					if err != nil {
+						return fmt.Errorf("mkdtemp bootloader: %w", err)
+					}
+					defer os.RemoveAll(bootloaderDir)
+					if err := kickstart.ExtractBootloader(stackSourceISO, bootloaderDir); err != nil {
+						return fmt.Errorf("extract bootloader: %w", err)
+					}
+					fmt.Fprintf(os.Stderr, "extracted bootloader from %s -> %s\n", stackSourceISO, bootloaderDir)
+
+					// Output dir for ISOs.
+					outDir := stackOutDir
+					if outDir == "" {
+						outDir, err = os.MkdirTemp("", "proxctl-stack-iso-")
+						if err != nil {
+							return fmt.Errorf("mkdtemp out: %w", err)
+						}
+					} else {
+						if err := os.MkdirAll(outDir, 0o755); err != nil {
+							return err
+						}
+					}
+
+					rnd, err := kickstart.NewRenderer()
+					if err != nil {
+						return err
+					}
+					builder := kickstart.NewISOBuilder(bootloaderDir)
+
+					var pveClient *proxmox.Client
+					if stackUpload {
+						client, err := loadProxmoxClient()
+						if err != nil {
+							return fmt.Errorf("load proxmox client: %w", err)
+						}
+						pveClient = client
+						if hyp.ISO == nil || hyp.ISO.KickstartStorage == "" {
+							return fmt.Errorf("--upload requires hypervisor.iso.kickstart_storage in env manifest")
+						}
+					}
+
+					for _, n := range nodes {
+						nodeCfg, ok := hyp.Nodes[n]
+						if !ok {
+							return fmt.Errorf("node %q vanished from hypervisor.nodes", n)
+						}
+						content, err := rnd.Render(env, n)
+						if err != nil {
+							return fmt.Errorf("render %s: %w", n, err)
+						}
+						isoPath, err := builder.Build(content, n)
+						if err != nil {
+							return fmt.Errorf("build iso %s: %w", n, err)
+						}
+						// Move into outDir if it's not already under there.
+						destPath := filepath.Join(outDir, filepath.Base(isoPath))
+						if isoPath != destPath {
+							if err := os.Rename(isoPath, destPath); err != nil {
+								// Cross-device fallback: copy + remove.
+								if err2 := copyISOFile(isoPath, destPath); err2 != nil {
+									return fmt.Errorf("relocate iso %s -> %s: %w (copy fallback: %v)", isoPath, destPath, err, err2)
+								}
+								_ = os.Remove(isoPath)
+							}
+							isoPath = destPath
+						}
+						fmt.Println(isoPath)
+
+						if stackUpload {
+							storage := hyp.ISO.KickstartStorage
+							pveNode := nodeCfg.Proxmox.NodeName
+							if pveNode == "" {
+								return fmt.Errorf("node %q has no proxmox.node_name", n)
+							}
+							if err := pveClient.UploadISO(context.Background(), pveNode, storage, isoPath, filepath.Base(isoPath)); err != nil {
+								return fmt.Errorf("upload %s -> %s/%s: %w", isoPath, pveNode, storage, err)
+							}
+							fmt.Fprintf(os.Stderr, "uploaded %s to %s:%s\n", filepath.Base(isoPath), pveNode, storage)
+							if !stackKeep {
+								_ = os.Remove(isoPath)
+							}
+						}
+					}
+					return nil
+				},
+			}
+			cc.Flags().StringVar(&stackNode, "node", "", "single node name (default: build all nodes in env)")
+			cc.Flags().StringVar(&stackSourceISO, "source-iso", "", "path to upstream OL install ISO (required)")
+			cc.Flags().StringVar(&stackOutDir, "out-dir", "", "output directory for per-host ISOs (default: tempdir)")
+			cc.Flags().BoolVar(&stackUpload, "upload", false, "upload each ISO to its node's hypervisor.iso.kickstart_storage")
+			cc.Flags().BoolVar(&stackKeep, "keep", false, "keep local ISOs after upload (default: delete)")
 			return cc
 		}(),
 		&cobra.Command{

--- a/pkg/kickstart/iso_extractor.go
+++ b/pkg/kickstart/iso_extractor.go
@@ -1,0 +1,72 @@
+package kickstart
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// RequiredBootloaderFiles lists the files an OL8/OL9 install ISO must contain
+// under /isolinux/ for the legacy ISOBuilder to remaster a kickstart-only ISO.
+var RequiredBootloaderFiles = []string{
+	"isolinux.bin",
+	"ldlinux.c32",
+	"vmlinuz",
+	"initrd.img",
+}
+
+// ExtractBootloader extracts the four files RequiredBootloaderFiles from the
+// /isolinux/ directory of sourceISO into destDir using xorriso -osirrox.
+// destDir must already exist.
+//
+// Implementation notes:
+//
+//   - Oracle Linux 8/9, RHEL 9, and Rocky 9 install ISOs ship the BIOS
+//     bootloader at /isolinux/. This is the canonical layout.
+//   - We use xorriso `-osirrox on` to read files out of an ISO. The
+//     `-extract <iso-path> <host-path>` form copies a directory; if the
+//     extraction overshoots and grabs extra files, that's harmless — we
+//     only verify the required four are present.
+//   - Older RHEL-family install ISOs sometimes name initrd.img differently
+//     (e.g. initrd-arm.img); for now we assume the canonical x86_64 layout.
+//     Future enhancement: glob + pick.
+func ExtractBootloader(sourceISO, destDir string) error {
+	if sourceISO == "" {
+		return fmt.Errorf("ExtractBootloader: sourceISO is required")
+	}
+	if destDir == "" {
+		return fmt.Errorf("ExtractBootloader: destDir is required")
+	}
+	if _, err := os.Stat(sourceISO); err != nil {
+		return fmt.Errorf("source ISO not found: %w", err)
+	}
+	if _, err := exec.LookPath("xorriso"); err != nil {
+		return fmt.Errorf("xorriso not found in PATH (install xorriso): %w", err)
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir destDir: %w", err)
+	}
+
+	// xorriso `-extract` copies the ISO source path into the host destination
+	// path. We extract /isolinux/ as a directory; xorriso will create destDir
+	// contents directly (not a nested isolinux/ subdir) when destDir already
+	// exists.
+	cmd := exec.Command("xorriso",
+		"-osirrox", "on",
+		"-indev", sourceISO,
+		"-extract", "/isolinux", destDir,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("xorriso extract /isolinux failed: %w: %s", err, string(out))
+	}
+
+	// Verify all required files are present.
+	for _, name := range RequiredBootloaderFiles {
+		p := filepath.Join(destDir, name)
+		if _, err := os.Stat(p); err != nil {
+			return fmt.Errorf("required bootloader file %q missing after extraction (looked in %s): %w", name, destDir, err)
+		}
+	}
+	return nil
+}

--- a/pkg/kickstart/iso_extractor_test.go
+++ b/pkg/kickstart/iso_extractor_test.go
@@ -1,0 +1,114 @@
+package kickstart
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestExtractBootloader_ValidationErrors covers the synchronous input checks
+// that don't require xorriso to be on PATH.
+func TestExtractBootloader_ValidationErrors(t *testing.T) {
+	if err := ExtractBootloader("", "/tmp/x"); err == nil {
+		t.Fatalf("expected error for empty sourceISO")
+	}
+	if err := ExtractBootloader("/some/iso", ""); err == nil {
+		t.Fatalf("expected error for empty destDir")
+	}
+	if err := ExtractBootloader("/nonexistent/path/to/missing.iso", t.TempDir()); err == nil {
+		t.Fatalf("expected error for missing source ISO")
+	}
+}
+
+// TestExtractBootloader_HappyPath builds a tiny test ISO with mock bootloader
+// files under /isolinux/ and verifies ExtractBootloader writes all four files.
+// Skipped when xorriso isn't installed (CI environment dependent).
+func TestExtractBootloader_HappyPath(t *testing.T) {
+	if _, err := exec.LookPath("xorriso"); err != nil {
+		t.Skip("xorriso not in PATH; skipping ISO extraction test")
+	}
+
+	tmp := t.TempDir()
+
+	// Stage a tree with /isolinux/<files>.
+	stage := filepath.Join(tmp, "stage")
+	isolinuxDir := filepath.Join(stage, "isolinux")
+	if err := os.MkdirAll(isolinuxDir, 0o755); err != nil {
+		t.Fatalf("mkdir stage: %v", err)
+	}
+	for _, name := range RequiredBootloaderFiles {
+		// Use distinct content per file so we can sanity-check the extraction
+		// preserved file boundaries.
+		content := []byte("mock-" + name)
+		if err := os.WriteFile(filepath.Join(isolinuxDir, name), content, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	// Build a minimal ISO. We don't need it to be bootable — only readable
+	// by xorriso -osirrox.
+	isoPath := filepath.Join(tmp, "test.iso")
+	cmd := exec.Command("xorriso", "-as", "mkisofs",
+		"-o", isoPath,
+		"-J", "-r",
+		"-V", "TEST",
+		stage,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build test ISO: %v: %s", err, string(out))
+	}
+
+	// Extract.
+	dest := filepath.Join(tmp, "out")
+	if err := ExtractBootloader(isoPath, dest); err != nil {
+		t.Fatalf("ExtractBootloader: %v", err)
+	}
+
+	// Verify each file is present and non-empty.
+	for _, name := range RequiredBootloaderFiles {
+		p := filepath.Join(dest, name)
+		fi, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("missing extracted file %s: %v", name, err)
+		}
+		if fi.Size() == 0 {
+			t.Fatalf("extracted file %s is empty", name)
+		}
+	}
+}
+
+// TestExtractBootloader_MissingFile builds an ISO with only some of the
+// required files and asserts the post-extract verification errors.
+func TestExtractBootloader_MissingFile(t *testing.T) {
+	if _, err := exec.LookPath("xorriso"); err != nil {
+		t.Skip("xorriso not in PATH; skipping ISO extraction test")
+	}
+
+	tmp := t.TempDir()
+	stage := filepath.Join(tmp, "stage")
+	isolinuxDir := filepath.Join(stage, "isolinux")
+	if err := os.MkdirAll(isolinuxDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Only stage isolinux.bin — vmlinuz, initrd.img, ldlinux.c32 missing.
+	if err := os.WriteFile(filepath.Join(isolinuxDir, "isolinux.bin"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	isoPath := filepath.Join(tmp, "test.iso")
+	cmd := exec.Command("xorriso", "-as", "mkisofs",
+		"-o", isoPath,
+		"-J", "-r",
+		"-V", "TEST",
+		stage,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build test ISO: %v: %s", err, string(out))
+	}
+
+	dest := filepath.Join(tmp, "out")
+	if err := ExtractBootloader(isoPath, dest); err == nil {
+		t.Fatalf("expected error for ISO missing required bootloader files")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `proxctl kickstart build-stack [ENV_FILE]` integrated build path mirroring `build-ubuntu` for Oracle Linux 8/9.
- New `pkg/kickstart/iso_extractor.go` (ExtractBootloader via xorriso -osirrox).
- Per-node render → build → optional mcp-proxmox upload; rejects ubuntu* distros.

Closes #56

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `proxctl kickstart build-stack --help` prints expected flags
- [x] `--source-iso` required (test)
- [x] ubuntu* distro rejected with hint (test)
- [x] Extractor happy-path test (xorriso-gated)
- [x] CHANGELOG.md updated for v2026.05.04.1