### PR TITLE
fix(kickstart): OL9 ks must include `url` primary install source (#61)

### DIFF
--- a/pkg/config/hypervisor.go
+++ b/pkg/config/hypervisor.go
@@ -87,6 +87,12 @@ type KickstartConfig struct {
 	Lang            string              `yaml:"lang,omitempty"             json:"lang,omitempty"`
 	Mode            string              `yaml:"mode,omitempty"             json:"mode,omitempty"             validate:"omitempty,oneof=text graphical"`
 	IPv6Enabled     bool                `yaml:"ipv6,omitempty"             json:"ipv6,omitempty"`
+	// InstallURL — primary base-OS install source for OL/RHEL kickstart. Must
+	// be set (or template default used) so Anaconda has a `url` directive;
+	// without one, Anaconda halts at "Installation source: Error setting up
+	// software source" because the kickstart-only ISO built by build-stack
+	// has no BaseOS/AppStream content. Default: yum.oracle.com OL9 baseos.
+	InstallURL      string              `yaml:"install_url,omitempty"      json:"install_url,omitempty"`
 	ChronyServers   []string            `yaml:"chrony_servers,omitempty"   json:"chrony_servers,omitempty"`
 	Sudo            *SudoConfig         `yaml:"sudo,omitempty"             json:"sudo,omitempty"`
 	Packages        *PackagesConfig     `yaml:"packages,omitempty"         json:"packages,omitempty"`

--- a/pkg/kickstart/renderer_test.go
+++ b/pkg/kickstart/renderer_test.go
@@ -96,11 +96,42 @@ func TestRendererOL9(t *testing.T) {
 		"firewall --enabled --ssh",
 		"pool.ntp.org",
 		"NOPASSWD",
+		// Anaconda primary install source — without this directive the kickstart
+		// halts at "Installation source: Error setting up software source" because
+		// the kickstart-only ISO has no BaseOS/AppStream content.
+		"url --url=https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/",
 	}
 	for _, s := range mustContain {
 		if !strings.Contains(out, s) {
 			t.Errorf("rendered kickstart missing %q\n---\n%s", s, out)
 		}
+	}
+}
+
+// TestRenderOL9_CustomInstallURL verifies operator override of the BaseOS
+// install source via Kickstart.InstallURL (e.g. for air-gapped mirrors).
+func TestRenderOL9_CustomInstallURL(t *testing.T) {
+	env := buildEnv()
+	custom := "https://mirror.internal.example.com/ol9/baseos/x86_64/"
+	env.Spec.Hypervisor.Inline.Kickstart.InstallURL = custom
+	r, err := NewRenderer()
+	if err != nil {
+		t.Fatalf("NewRenderer: %v", err)
+	}
+	out, err := r.Render(env, "web01")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	wantLine := "url --url=" + custom
+	if !strings.Contains(out, wantLine) {
+		t.Errorf("rendered kickstart missing custom install URL %q\n---\n%s", wantLine, out)
+	}
+	// Ensure the default `url --url=` line was not also emitted (would indicate
+	// the template ignored the override). The default base URL still appears in
+	// the `repo --name=ol9_baseos` directive, which is intentional and unrelated.
+	defaultURLLine := "url --url=https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/"
+	if strings.Contains(out, defaultURLLine) {
+		t.Errorf("rendered kickstart emitted default `url --url=` line despite override\n---\n%s", out)
 	}
 }
 

--- a/pkg/kickstart/templates/oraclelinux9/base.ks.tmpl
+++ b/pkg/kickstart/templates/oraclelinux9/base.ks.tmpl
@@ -18,6 +18,15 @@ timezone --utc {{ if .Kickstart.Timezone }}{{ .Kickstart.Timezone }}{{ else }}UT
 # Network
 {{ template "network" . }}
 
+# Primary install source — REQUIRED. Without a `url`/`cdrom`/`nfs` directive
+# Anaconda halts at "Installation source: Error setting up software source"
+# even when the boot media has the kickstart loaded. The kickstart-only ISO
+# built by `proxctl kickstart build-stack` contains only bootloader + ks.cfg
+# (no BaseOS/AppStream repo content), so Anaconda cannot fall back to boot
+# media. Use Oracle's public yum mirror (signed, no MOS account, network
+# already configured above). Override via env.yaml `kickstart.install_url`.
+url --url={{ if .Kickstart.InstallURL }}{{ .Kickstart.InstallURL }}{{ else }}https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/{{ end }}
+
 # Disk / bootloader
 {{ template "disk" . }}
 


### PR DESCRIPTION
Closes #61.

## Summary

OL9 kickstart was missing a primary install source directive (`url`/`cdrom`/`nfs`). The kickstart-only ISO produced by `build-stack` has bootloader + ks.cfg only (no BaseOS/AppStream RPMs), so Anaconda halted at the interactive menu with `Installation source: Error setting up software source` — install hung indefinitely.

## Changes

- Add `url --url=…` directive after the network block in `oraclelinux9/base.ks.tmpl`. Default: public Oracle yum mirror. Override: `kickstart.install_url` in env.yaml (for air-gapped operators).
- Add `KickstartConfig.InstallURL` config field.
- Extend `TestRendererOL9` to assert the default `url` line is rendered.
- New `TestRenderOL9_CustomInstallURL` verifies operator override.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] Stage 2 E2E: regenerated ISOs let VMs 2701+2702 complete OL9 install + become SSH-reachable (happens post-merge in the test session)

## Follow-up

OL8 template has the same defect — separate issue when OL8 returns to the test matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)