### PR TITLE
fix(kickstart): inject inst.stage2/inst.repo=hd:LABEL into APPEND (Path B-lite) (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.05.04.4 — 2026-05-04
+
+### fix(kickstart): inject inst.stage2/inst.repo=hd:LABEL into APPEND (Path B-lite) (#63)
+
+Even with `url` set in the ks.cfg (#61, v2026.05.04.3), Anaconda on OL9
+fails in dracut-initqueue with DNS errors when fetching stage2 from
+`yum.oracle.com`. The kickstart-only ISO doesn't carry stage2 itself, and
+dracut runs before the kickstart `network` directive applies, so the
+stage2 fetch races DNS configuration in lab subnets without an upstream
+resolver.
+
+Fix (operator-approved Path B-lite — avoids the 10 GB full-remaster path):
+have Anaconda read stage2 + the package repo from the **second CDROM
+drive** attached to the VM, which carries the full upstream OL9 install
+ISO. Anaconda matches by ISO9660 volume label, so the kernel cmdline
+remains stable regardless of which CDROM device (sr0/sr1) Anaconda
+probes first.
+
+- `pkg/kickstart/iso_builder.go` — new `ISOBuilder.SourceISOLabel` field;
+  when set, the generated `isolinux.cfg` APPEND line becomes:
+  `APPEND initrd=initrd.img ip=dhcp inst.stage2=hd:LABEL=<label> inst.repo=hd:LABEL=<label> inst.ks=cdrom:/ks.cfg inst.text`.
+  Empty label preserves the legacy minimal APPEND (back-compat).
+- `pkg/kickstart/iso_extractor.go` — new `ReadVolumeLabel(iso)` parses
+  `xorriso -indev <iso> -toc` output for the `Volume id` line.
+- `internal/root/kickstart.go` — `build-stack` subcommand now reads the
+  upstream ISO's volume label automatically and passes it to the
+  builder.
+
+Tests: `TestBuildIsolinuxCfg_NoLabel` (back-compat) and
+`TestBuildIsolinuxCfg_WithLabel` (Path B-lite).
+
+Operator workflow: keep the full OL9 install ISO attached at `ide2` on
+each VM; rebuild the kickstart ISO with `proxctl kickstart build-stack`
+(label flows through automatically); start the VM. Anaconda finds
+stage2 + repo on the local CDROM drive — no DNS, no network repo.
+
 ## v2026.05.04.3 — 2026-05-04
 
 ### fix(kickstart): OL9 ks must include `url` primary install source (#61)

--- a/internal/root/kickstart.go
+++ b/internal/root/kickstart.go
@@ -298,6 +298,16 @@ Errors out for ubuntu* distros — use ` + "`build-ubuntu`" + ` instead.`,
 					}
 					fmt.Fprintf(os.Stderr, "extracted bootloader from %s -> %s\n", stackSourceISO, bootloaderDir)
 
+					// Read upstream ISO volume label so Anaconda can locate
+					// stage2 + repo on the second CDROM drive (Path B-lite,
+					// fixes dracut-initqueue DNS errors fetching stage2 from
+					// the network).
+					sourceLabel, err := kickstart.ReadVolumeLabel(stackSourceISO)
+					if err != nil {
+						return fmt.Errorf("read source ISO volume label: %w", err)
+					}
+					fmt.Fprintf(os.Stderr, "source ISO volume label: %s\n", sourceLabel)
+
 					// Output dir for ISOs.
 					outDir := stackOutDir
 					if outDir == "" {
@@ -316,6 +326,7 @@ Errors out for ubuntu* distros — use ` + "`build-ubuntu`" + ` instead.`,
 						return err
 					}
 					builder := kickstart.NewISOBuilder(bootloaderDir)
+					builder.SourceISOLabel = sourceLabel
 
 					var pveClient *proxmox.Client
 					if stackUpload {

--- a/pkg/kickstart/iso_builder.go
+++ b/pkg/kickstart/iso_builder.go
@@ -17,6 +17,15 @@ type ISOBuilder struct {
 	BootloaderDir string
 	// WorkDir is the temp dir root. Defaults to os.TempDir() when empty.
 	WorkDir string
+	// SourceISOLabel is the ISO9660 volume ID of the *upstream* full install ISO.
+	// When non-empty, the generated isolinux.cfg APPEND line includes
+	// `ip=dhcp inst.stage2=hd:LABEL=<label> inst.repo=hd:LABEL=<label>` so
+	// Anaconda reads stage2 + the package repo from a second CDROM drive
+	// attached to the VM that carries the full install ISO. This avoids
+	// fetching stage2 over the network (which fails in dracut-initqueue when
+	// DNS isn't yet configured). When empty, the legacy minimal APPEND is
+	// emitted (back-compat).
+	SourceISOLabel string
 }
 
 // NewISOBuilder creates a builder auto-detecting the ISO tool.
@@ -86,13 +95,11 @@ func (b *ISOBuilder) Build(kickstartContent, hostname string) (string, error) {
 	// those mode bits when staging the bootloader into buildDir, so a plain
 	// os.WriteFile over the pre-existing read-only file fails with EACCES.
 	// Remove any stale isolinux.cfg first; we always author our own here.
-	isolinuxCfg := `DEFAULT linux
-PROMPT 0
-TIMEOUT 10
-LABEL linux
-  KERNEL vmlinuz
-  APPEND initrd=initrd.img inst.ks=cdrom:/ks.cfg inst.text
-`
+	// APPEND line: when SourceISOLabel is set, point Anaconda at the upstream
+	// full ISO via volume label so stage2 + repo load from the second CDROM
+	// drive attached to the VM. Without it, Anaconda tries to fetch stage2
+	// from the network and fails in dracut-initqueue if DNS isn't ready.
+	isolinuxCfg := buildIsolinuxCfg(b.SourceISOLabel)
 	isolinuxPath := filepath.Join(buildDir, "isolinux.cfg")
 	_ = os.Remove(isolinuxPath)
 	if err := os.WriteFile(isolinuxPath, []byte(isolinuxCfg), 0o644); err != nil {
@@ -138,6 +145,24 @@ LABEL linux
 		return "", fmt.Errorf("%s failed: %w: %s", b.Tool, err, string(out))
 	}
 	return outPath, nil
+}
+
+// buildIsolinuxCfg returns the isolinux.cfg content for a kickstart-only ISO.
+// When sourceISOLabel is non-empty, the APPEND line points Anaconda at a
+// second CDROM drive (carrying the full upstream install ISO) for stage2 +
+// the package repo, via ISO9660 volume-label match. When empty, a minimal
+// APPEND is emitted (back-compat with v2026.05.04.3 and earlier).
+func buildIsolinuxCfg(sourceISOLabel string) string {
+	var appendLine string
+	if sourceISOLabel != "" {
+		appendLine = fmt.Sprintf(
+			"  APPEND initrd=initrd.img ip=dhcp inst.stage2=hd:LABEL=%s inst.repo=hd:LABEL=%s inst.ks=cdrom:/ks.cfg inst.text\n",
+			sourceISOLabel, sourceISOLabel,
+		)
+	} else {
+		appendLine = "  APPEND initrd=initrd.img inst.ks=cdrom:/ks.cfg inst.text\n"
+	}
+	return "DEFAULT linux\nPROMPT 0\nTIMEOUT 10\nLABEL linux\n  KERNEL vmlinuz\n" + appendLine
 }
 
 // copyDir copies regular files from src into dst (non-recursive; we assume flat bootloader dir).

--- a/pkg/kickstart/iso_builder_test.go
+++ b/pkg/kickstart/iso_builder_test.go
@@ -3,8 +3,40 @@ package kickstart
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// TestBuildIsolinuxCfg_NoLabel verifies back-compat: empty SourceISOLabel
+// emits the legacy minimal APPEND line.
+func TestBuildIsolinuxCfg_NoLabel(t *testing.T) {
+	got := buildIsolinuxCfg("")
+	if !strings.Contains(got, "APPEND initrd=initrd.img inst.ks=cdrom:/ks.cfg inst.text") {
+		t.Errorf("expected legacy minimal APPEND, got:\n%s", got)
+	}
+	if strings.Contains(got, "inst.stage2") || strings.Contains(got, "inst.repo") {
+		t.Errorf("legacy APPEND should not include inst.stage2/inst.repo, got:\n%s", got)
+	}
+}
+
+// TestBuildIsolinuxCfg_WithLabel verifies Path B-lite: when SourceISOLabel
+// is set, the APPEND line includes ip=dhcp + inst.stage2=hd:LABEL= +
+// inst.repo=hd:LABEL= using the supplied label.
+func TestBuildIsolinuxCfg_WithLabel(t *testing.T) {
+	const label = "OL-9-4-0-BaseOS-x86_64"
+	got := buildIsolinuxCfg(label)
+	for _, want := range []string{
+		"ip=dhcp",
+		"inst.stage2=hd:LABEL=" + label,
+		"inst.repo=hd:LABEL=" + label,
+		"inst.ks=cdrom:/ks.cfg",
+		"inst.text",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("APPEND missing %q, got:\n%s", want, got)
+		}
+	}
+}
 
 // helperPATH points PATH at a tempdir and optionally writes fake executables.
 // It restores the original PATH via t.Cleanup.

--- a/pkg/kickstart/iso_extractor.go
+++ b/pkg/kickstart/iso_extractor.go
@@ -1,11 +1,59 @@
 package kickstart
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
+
+// ReadVolumeLabel returns the ISO9660 volume ID (Volume id) of sourceISO using
+// xorriso. The label is what Anaconda matches against `inst.stage2=hd:LABEL=`
+// and `inst.repo=hd:LABEL=` so the kickstart-only ISO can find the upstream
+// full install ISO attached at a second CDROM drive on the VM.
+//
+// Implementation: parses `xorriso -indev <iso> -toc -report_about WARNING`
+// output for the line `Volume id    : <label>`.
+func ReadVolumeLabel(sourceISO string) (string, error) {
+	if sourceISO == "" {
+		return "", fmt.Errorf("ReadVolumeLabel: sourceISO is required")
+	}
+	if _, err := os.Stat(sourceISO); err != nil {
+		return "", fmt.Errorf("source ISO not found: %w", err)
+	}
+	if _, err := exec.LookPath("xorriso"); err != nil {
+		return "", fmt.Errorf("xorriso not found in PATH: %w", err)
+	}
+	cmd := exec.Command("xorriso",
+		"-indev", sourceISO,
+		"-report_about", "WARNING",
+		"-toc",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("xorriso -toc failed: %w: %s", err, string(out))
+	}
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// Match e.g. "Volume id    : 'OL-9-4-0-BaseOS-x86_64'"
+		// or "Volume id    : OL-9-4-0-BaseOS-x86_64"
+		if strings.HasPrefix(line, "Volume id") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			label := strings.TrimSpace(parts[1])
+			label = strings.Trim(label, "'\"")
+			if label != "" {
+				return label, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("could not find Volume id in xorriso -toc output")
+}
 
 // RequiredBootloaderFiles lists the files an OL8/OL9 install ISO must contain
 // under /isolinux/ for the legacy ISOBuilder to remaster a kickstart-only ISO.


### PR DESCRIPTION
Closes #63.

## Summary
- New `ISOBuilder.SourceISOLabel` field — when set, isolinux.cfg APPEND becomes `... ip=dhcp inst.stage2=hd:LABEL=<l> inst.repo=hd:LABEL=<l> inst.ks=cdrom:/ks.cfg inst.text` so Anaconda reads stage2 + the package repo from a second CDROM drive (upstream full install ISO at ide2). Empty label preserves the legacy minimal APPEND (back-compat).
- New `ReadVolumeLabel(iso)` parses `xorriso -indev <iso> -toc` output for the `Volume id` line.
- `build-stack` reads the source ISO label automatically and threads it through to the builder.

## Why
Even with `url` in ks.cfg (#61, v2026.05.04.3), Anaconda fails in dracut-initqueue with DNS errors when fetching stage2 from yum.oracle.com. dracut runs before the kickstart `network` directive applies, so the stage2 fetch races DNS configuration in lab subnets. Operator-approved Path B-lite avoids the 10 GB full-remaster path while achieving the same architectural correctness (no dracut DNS dependency).

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` passes
- [x] `TestBuildIsolinuxCfg_NoLabel` (back-compat path)
- [x] `TestBuildIsolinuxCfg_WithLabel` (Path B-lite path)
- [ ] Live: rebuild ext3+ext4 kickstart ISOs with v2026.05.04.4 and confirm VMs 2701+2702 install Anaconda end-to-end without DNS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)