### PR TITLE
feat(workflow): post-install finalize — detach ide2/ide3, reset boot order (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.05.04.6 — 2026-05-04
+
+### feat(workflow): post-install finalize — detach ide2/ide3, reset boot order to scsi0 (#67)
+
+Closes the kickstart install-loop bug hit live during ext3 Stage 2 on
+2026-05-04. After Anaconda finishes the kickstart install on scsi0 and
+reboots, ide3 (kickstart ISO) is still attached and still bootable. With
+ide3 ahead of scsi0 in the boot order (which is required for the *first*
+install), BIOS re-enters the kickstart ISO on the second boot —
+**install loop**.
+
+The fix adds a finalize step to the workflow lifecycle:
+
+1. Poll for SSH-up on the node's management/public IP (TCP :22 + banner
+   detection), default 30 min timeout.
+2. Detach ide3 (kickstart ISO) via `qm set <vmid> -delete ide3`.
+3. Detach ide2 (install ISO) via `qm set <vmid> -delete ide2`.
+4. Reset boot order to `order=scsi0` (single device).
+
+CLI surface:
+- New `proxctl workflow finalize` subcommand — single-node + multi-node.
+  Idempotent; safe to re-run on already-finalised VMs.
+- `proxctl workflow up` now runs finalize automatically; opt out via
+  `--skip-finalize`.
+- `--finalize-timeout <duration>` overrides the default 30 min SSH-up wait.
+
+Files touched:
+- `pkg/workflow/finalize.go` — new `FinalizeOptions`, `waitForSSHUp` (TCP
+  dial + banner check), `pickFinalizeIP` (priority: management → public →
+  private → any), `FinalizeSingle`, `SingleVMWorkflow.Finalize`,
+  `MultiNodeWorkflow.Finalize`.
+- `pkg/workflow/single_vm.go` — `SingleVMWorkflow.SkipFinalize` +
+  `FinalizeOptions` fields; `Up` invokes finalize unless `SkipFinalize`
+  or `DryRun` is set.
+- `pkg/workflow/multi_node.go` — same on `MultiNodeWorkflow`; per-node
+  inheritance via `perNode`.
+- `internal/root/workflow.go` — new `finalize` subcommand, `--skip-finalize`
+  on `up`, shared `--finalize-timeout` on `up` + `finalize`.
+- `pkg/workflow/finalize_test.go` — unit tests for IP priority, SSH-up
+  polling (banner seen, retries, timeout, no-IP, skip mode, non-SSH
+  banner ignored), defaults/overrides, and a httptest integration test
+  that asserts the exact qm-set sequence (delete ide3 → delete ide2 →
+  boot=order=scsi0).
+
 ## v2026.05.04.5 — 2026-05-04
 
 ### fix(kickstart): ReadVolumeLabel xorriso flags (#65)

--- a/internal/root/workflow.go
+++ b/internal/root/workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"text/tabwriter"
+	"time"
 
 	"github.com/itunified-io/proxctl/pkg/config"
 	"github.com/itunified-io/proxctl/pkg/kickstart"
@@ -37,6 +38,8 @@ func newWorkflowCmd() *cobra.Command {
 	var wfMaxConc int
 	var wfContinue bool
 	var wfSkipKickstart bool
+	var wfSkipFinalize bool
+	var wfFinalizeTimeout time.Duration
 
 	loadCommon := func() (*config.Env, *kickstart.Renderer, *kickstart.ISOBuilder, error) {
 		env, err := loadEnvManifest("")
@@ -67,6 +70,10 @@ func newWorkflowCmd() *cobra.Command {
 			Builder:            builder,
 			DryRun:             wfDryRun,
 			SkipKickstartBuild: wfSkipKickstart,
+			SkipFinalize:       wfSkipFinalize,
+			FinalizeOptions: workflow.FinalizeOptions{
+				Timeout: wfFinalizeTimeout,
+			},
 		}, nil
 	}
 
@@ -82,6 +89,8 @@ func newWorkflowCmd() *cobra.Command {
 		}
 		m.ContinueOnError = wfContinue
 		m.SkipKickstartBuild = wfSkipKickstart
+		m.SkipFinalize = wfSkipFinalize
+		m.FinalizeOptions = workflow.FinalizeOptions{Timeout: wfFinalizeTimeout}
 		return m, nil
 	}
 
@@ -263,7 +272,45 @@ func newWorkflowCmd() *cobra.Command {
 		},
 	}
 
-	for _, sub := range []*cobra.Command{planCmd, upCmd, downCmd, verifyCmd} {
+	finalizeCmd := &cobra.Command{
+		Use:   "finalize",
+		Short: "Post-install: wait for SSH-up, detach install/kickstart ISOs, reset boot order to scsi0 (#67)",
+		Long: `finalize closes the kickstart install loop:
+
+  1. Polls for SSH-up on the node's management/public IP (TCP :22 + banner)
+  2. Detaches the kickstart ISO (ide3) and install ISO (ide2) from the VM
+  3. Resets the boot order to scsi0 (single device)
+
+This step runs automatically as part of "workflow up" unless --skip-finalize
+is passed. Re-run standalone on already-installed VMs to recover from a
+previous run that exited before finalize completed.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			env, rnd, builder, err := loadCommon()
+			if err != nil {
+				if wfNode == "" {
+					return fmt.Errorf("--node required for single-node workflow")
+				}
+				return err
+			}
+			if isMultiNode(env) && wfNode == "" {
+				m, err := makeMulti(env, rnd, builder)
+				if err != nil {
+					return err
+				}
+				return m.Finalize(context.Background())
+			}
+			if wfNode == "" {
+				return fmt.Errorf("--node required for single-node workflow")
+			}
+			w, err := makeSingle(env, rnd, builder, wfNode)
+			if err != nil {
+				return err
+			}
+			return w.Finalize(context.Background())
+		},
+	}
+
+	for _, sub := range []*cobra.Command{planCmd, upCmd, downCmd, verifyCmd, finalizeCmd} {
 		sub.Flags().StringVar(&wfNode, "node", "", "node name from env manifest (single-node override)")
 		sub.Flags().StringVar(&wfBootloader, "bootloader-dir", "", "path to bootloader files (isolinux.bin, vmlinuz, initrd.img)")
 	}
@@ -275,9 +322,15 @@ func newWorkflowCmd() *cobra.Command {
 	upCmd.Flags().BoolVar(&wfDryRun, "dry-run", false, "print actions without executing")
 	upCmd.Flags().IntVar(&wfMaxConc, "max-concurrency", 0, "cap concurrent per-node Apply goroutines (0=default)")
 	upCmd.Flags().BoolVar(&wfContinue, "continue-on-error", false, "keep running remaining nodes when one fails")
+	upCmd.Flags().BoolVar(&wfSkipFinalize, "skip-finalize", false,
+		"skip the post-install finalize step (SSH-up wait + detach ide2/ide3 + reset boot order); see #67")
+	for _, sub := range []*cobra.Command{upCmd, finalizeCmd} {
+		sub.Flags().DurationVar(&wfFinalizeTimeout, "finalize-timeout", 0,
+			"max wait for SSH-up during finalize (default 30m)")
+	}
 	downCmd.Flags().BoolVar(&wfForce, "force", false, "hard stop instead of ACPI shutdown")
 
-	c.AddCommand(planCmd, upCmd, downCmd, statusCmd, verifyCmd, newWorkflowProfileCmd())
+	c.AddCommand(planCmd, upCmd, downCmd, statusCmd, verifyCmd, finalizeCmd, newWorkflowProfileCmd())
 	return c
 }
 

--- a/pkg/workflow/finalize.go
+++ b/pkg/workflow/finalize.go
@@ -1,0 +1,240 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/itunified-io/proxctl/pkg/config"
+	"github.com/itunified-io/proxctl/pkg/proxmox"
+)
+
+// DefaultFinalizeTimeout is the maximum time finalize waits for SSH-up
+// before giving up. Generous because a kickstart install on slow disks +
+// slow networks can take 20+ min; we still want a hard ceiling.
+const DefaultFinalizeTimeout = 30 * time.Minute
+
+// DefaultFinalizePollInterval is how often finalize retries the SSH-up
+// probe between attempts.
+const DefaultFinalizePollInterval = 10 * time.Second
+
+// sshDialer is the net.Dial signature, parameterised so tests can inject a
+// fake. Production code wires this to a net.Dialer with timeout.
+type sshDialer func(ctx context.Context, network, address string) (net.Conn, error)
+
+// FinalizeOptions controls SSH-up polling and post-install cleanup.
+//
+// The defaults (Timeout = 30m, PollInterval = 10s) are sized for a slow
+// kickstart install on commodity SATA + 1G LAN. Override via
+// SingleVMWorkflow / MultiNodeWorkflow fields when calling Up.
+type FinalizeOptions struct {
+	// Timeout caps the SSH-up wait. Zero → DefaultFinalizeTimeout.
+	Timeout time.Duration
+	// PollInterval gates retry frequency. Zero → DefaultFinalizePollInterval.
+	PollInterval time.Duration
+	// SSHPort is the TCP port to probe. Zero → 22.
+	SSHPort int
+	// Dialer overrides the default TCP dialer (for tests). Production callers
+	// leave this nil.
+	Dialer sshDialer
+	// SkipSSHWait is for tests / re-runs where SSH-up has already been verified
+	// out-of-band. Production callers leave this false.
+	SkipSSHWait bool
+}
+
+func (o *FinalizeOptions) timeout() time.Duration {
+	if o == nil || o.Timeout <= 0 {
+		return DefaultFinalizeTimeout
+	}
+	return o.Timeout
+}
+
+func (o *FinalizeOptions) pollInterval() time.Duration {
+	if o == nil || o.PollInterval <= 0 {
+		return DefaultFinalizePollInterval
+	}
+	return o.PollInterval
+}
+
+func (o *FinalizeOptions) sshPort() int {
+	if o == nil || o.SSHPort <= 0 {
+		return 22
+	}
+	return o.SSHPort
+}
+
+func (o *FinalizeOptions) dialer() sshDialer {
+	if o != nil && o.Dialer != nil {
+		return o.Dialer
+	}
+	d := &net.Dialer{Timeout: 5 * time.Second}
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		return d.DialContext(ctx, network, address)
+	}
+}
+
+// pickFinalizeIP selects the IP address to probe for SSH-up.
+//
+// Priority: management → public → private → any (first by key sort).
+// Returns the IP string and a label describing which slot was chosen, or
+// ("", "") if no IPs are configured.
+func pickFinalizeIP(ips map[string]string) (ip, label string) {
+	if len(ips) == 0 {
+		return "", ""
+	}
+	for _, k := range []string{"management", "public", "private"} {
+		if v, ok := ips[k]; ok && v != "" {
+			return v, k
+		}
+	}
+	keys := make([]string, 0, len(ips))
+	for k := range ips {
+		if ips[k] != "" {
+			keys = append(keys, k)
+		}
+	}
+	if len(keys) == 0 {
+		return "", ""
+	}
+	sort.Strings(keys)
+	return ips[keys[0]], keys[0]
+}
+
+// waitForSSHUp polls a TCP :22 connection until the SSH banner ("SSH-") is
+// observed, or the deadline fires. Returns nil on success.
+func waitForSSHUp(ctx context.Context, ip string, opts *FinalizeOptions) error {
+	if opts != nil && opts.SkipSSHWait {
+		return nil
+	}
+	if ip == "" {
+		return errors.New("finalize: no IP available for SSH-up probe")
+	}
+	addr := net.JoinHostPort(ip, fmt.Sprintf("%d", opts.sshPort()))
+	dial := opts.dialer()
+
+	deadline := time.Now().Add(opts.timeout())
+	interval := opts.pollInterval()
+
+	var lastErr error
+	for {
+		if time.Now().After(deadline) {
+			if lastErr == nil {
+				lastErr = fmt.Errorf("timeout after %s", opts.timeout())
+			}
+			return fmt.Errorf("finalize: ssh-up wait %s: %w", addr, lastErr)
+		}
+		dctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		conn, err := dial(dctx, "tcp", addr)
+		cancel()
+		if err == nil {
+			// Read up to ~32 bytes of banner; SSH servers send "SSH-2.0-..."
+			_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+			buf := make([]byte, 64)
+			n, rerr := conn.Read(buf)
+			_ = conn.Close()
+			if rerr == nil && n > 0 && strings.HasPrefix(string(buf[:n]), "SSH-") {
+				return nil
+			}
+			lastErr = fmt.Errorf("connected but no SSH banner (read=%d, err=%v)", n, rerr)
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}
+
+// FinalizeSingle detaches the install + kickstart ISOs from one VM and
+// resets the boot order to just scsi0. Caller is responsible for ensuring
+// the VM has reached a steady state (typically via waitForSSHUp).
+//
+// The detach calls are best-effort — Proxmox returns 200 + null when the
+// slot is already absent, which is fine for re-runs.
+func FinalizeSingle(ctx context.Context, client *proxmox.Client, node string, vmid int) error {
+	if client == nil {
+		return errors.New("finalize: Client not set")
+	}
+	// Order: kickstart (ide3) first, then install (ide2). If a partial
+	// previous run left ide3 detached, EjectISO is idempotent enough that
+	// the second call still works.
+	if err := client.EjectISO(ctx, node, vmid, "ide3"); err != nil {
+		return fmt.Errorf("finalize: detach ide3 (kickstart): %w", err)
+	}
+	if err := client.EjectISO(ctx, node, vmid, "ide2"); err != nil {
+		return fmt.Errorf("finalize: detach ide2 (install): %w", err)
+	}
+	if err := client.SetBootOrder(ctx, node, vmid, "scsi0"); err != nil {
+		return fmt.Errorf("finalize: reset boot order: %w", err)
+	}
+	return nil
+}
+
+// Finalize is the SingleVMWorkflow finalize entrypoint. It is idempotent and
+// safe to re-run on already-finalised VMs.
+func (w *SingleVMWorkflow) Finalize(ctx context.Context) error {
+	r, err := w.resolve()
+	if err != nil {
+		return err
+	}
+	if w.Client == nil {
+		return errors.New("finalize: Client not set")
+	}
+	ip, label := pickFinalizeIP(r.node.IPs)
+	if ip == "" {
+		return fmt.Errorf("finalize: node %q has no IPs configured (cannot probe SSH-up)", w.NodeName)
+	}
+	opts := w.FinalizeOptions
+	fmt.Fprintf(os.Stderr, "[finalize:%s] waiting for SSH-up at %s (%s, timeout %s)\n",
+		w.NodeName, ip, label, opts.timeout())
+	if err := waitForSSHUp(ctx, ip, &opts); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "[finalize:%s] SSH-up ✓ — detaching ide3+ide2, resetting boot order\n", w.NodeName)
+	return FinalizeSingle(ctx, w.Client, r.node.Proxmox.NodeName, r.node.Proxmox.VMID)
+}
+
+// nodesForFinalize returns the deterministic sorted node list (mirrors
+// MultiNodeWorkflow.nodeNames so it works without exporting that helper).
+func (m *MultiNodeWorkflow) nodesForFinalize() ([]string, *config.Hypervisor, error) {
+	if m.Config == nil {
+		return nil, nil, errors.New("finalize: Config is nil")
+	}
+	hyp := m.Config.Spec.Hypervisor.Resolved()
+	if hyp == nil {
+		return nil, nil, errors.New("finalize: hypervisor not resolved")
+	}
+	names := make([]string, 0, len(hyp.Nodes))
+	for n := range hyp.Nodes {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names, hyp, nil
+}
+
+// Finalize fans the per-node finalize step out across the manifest.
+//
+// Errors are aggregated so the caller sees every node that failed.
+func (m *MultiNodeWorkflow) Finalize(ctx context.Context) error {
+	names, _, err := m.nodesForFinalize()
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, name := range names {
+		w := m.perNode(name)
+		w.FinalizeOptions = m.FinalizeOptions
+		if err := w.Finalize(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/pkg/workflow/finalize_test.go
+++ b/pkg/workflow/finalize_test.go
@@ -1,0 +1,226 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/itunified-io/proxctl/pkg/proxmox"
+)
+
+func TestPickFinalizeIP_Priority(t *testing.T) {
+	cases := []struct {
+		name      string
+		ips       map[string]string
+		wantIP    string
+		wantLabel string
+	}{
+		{"empty", map[string]string{}, "", ""},
+		{"nil", nil, "", ""},
+		{"management wins", map[string]string{"management": "10.0.0.1", "public": "1.1.1.1", "private": "10.10.0.1"}, "10.0.0.1", "management"},
+		{"public when no management", map[string]string{"public": "1.1.1.1", "private": "10.10.0.1"}, "1.1.1.1", "public"},
+		{"private when no public", map[string]string{"private": "10.10.0.1"}, "10.10.0.1", "private"},
+		{"any when no canonical key", map[string]string{"vip": "10.20.0.5", "scan": "10.20.0.6"}, "10.20.0.6", "scan"},
+		{"empty value skipped", map[string]string{"management": "", "public": "1.2.3.4"}, "1.2.3.4", "public"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ip, label := pickFinalizeIP(tc.ips)
+			assert.Equal(t, tc.wantIP, ip)
+			assert.Equal(t, tc.wantLabel, label)
+		})
+	}
+}
+
+// fakeSSHConn returns the bytes provided as the SSH banner on first read.
+type fakeSSHConn struct {
+	banner []byte
+	read   int32
+}
+
+func (f *fakeSSHConn) Read(b []byte) (int, error) {
+	if atomic.AddInt32(&f.read, 1) > 1 {
+		return 0, errors.New("eof")
+	}
+	n := copy(b, f.banner)
+	return n, nil
+}
+func (f *fakeSSHConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (f *fakeSSHConn) Close() error                     { return nil }
+func (f *fakeSSHConn) LocalAddr() net.Addr              { return nil }
+func (f *fakeSSHConn) RemoteAddr() net.Addr             { return nil }
+func (f *fakeSSHConn) SetDeadline(time.Time) error      { return nil }
+func (f *fakeSSHConn) SetReadDeadline(time.Time) error  { return nil }
+func (f *fakeSSHConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestWaitForSSHUp_BannerSeen(t *testing.T) {
+	calls := int32(0)
+	dialer := func(ctx context.Context, network, address string) (net.Conn, error) {
+		atomic.AddInt32(&calls, 1)
+		return &fakeSSHConn{banner: []byte("SSH-2.0-OpenSSH_9.6\r\n")}, nil
+	}
+	opts := &FinalizeOptions{
+		Timeout:      2 * time.Second,
+		PollInterval: 10 * time.Millisecond,
+		Dialer:       dialer,
+	}
+	err := waitForSSHUp(context.Background(), "10.0.0.1", opts)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func TestWaitForSSHUp_RetriesUntilBanner(t *testing.T) {
+	calls := int32(0)
+	dialer := func(ctx context.Context, network, address string) (net.Conn, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			return nil, errors.New("connection refused")
+		}
+		return &fakeSSHConn{banner: []byte("SSH-2.0-x")}, nil
+	}
+	opts := &FinalizeOptions{
+		Timeout:      2 * time.Second,
+		PollInterval: 5 * time.Millisecond,
+		Dialer:       dialer,
+	}
+	err := waitForSSHUp(context.Background(), "10.0.0.1", opts)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(3))
+}
+
+func TestWaitForSSHUp_TimeoutReturnsErr(t *testing.T) {
+	dialer := func(ctx context.Context, network, address string) (net.Conn, error) {
+		return nil, errors.New("connection refused")
+	}
+	opts := &FinalizeOptions{
+		Timeout:      80 * time.Millisecond,
+		PollInterval: 20 * time.Millisecond,
+		Dialer:       dialer,
+	}
+	err := waitForSSHUp(context.Background(), "10.0.0.1", opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ssh-up wait")
+}
+
+func TestWaitForSSHUp_NoIP(t *testing.T) {
+	err := waitForSSHUp(context.Background(), "", &FinalizeOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no IP")
+}
+
+func TestWaitForSSHUp_SkipMode(t *testing.T) {
+	// SkipSSHWait should return nil immediately even with empty IP.
+	err := waitForSSHUp(context.Background(), "", &FinalizeOptions{SkipSSHWait: true})
+	require.NoError(t, err)
+}
+
+func TestWaitForSSHUp_ConnectsButNoBanner(t *testing.T) {
+	calls := int32(0)
+	dialer := func(ctx context.Context, network, address string) (net.Conn, error) {
+		n := atomic.AddInt32(&calls, 1)
+		// First few opens return non-SSH garbage so we treat as not-yet-up
+		if n < 2 {
+			return &fakeSSHConn{banner: []byte("HTTP/1.1 ...")}, nil
+		}
+		return &fakeSSHConn{banner: []byte("SSH-2.0-x")}, nil
+	}
+	opts := &FinalizeOptions{
+		Timeout:      2 * time.Second,
+		PollInterval: 5 * time.Millisecond,
+		Dialer:       dialer,
+	}
+	require.NoError(t, waitForSSHUp(context.Background(), "10.0.0.1", opts))
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2))
+}
+
+func TestFinalizeOptions_Defaults(t *testing.T) {
+	var o FinalizeOptions
+	assert.Equal(t, DefaultFinalizeTimeout, o.timeout())
+	assert.Equal(t, DefaultFinalizePollInterval, o.pollInterval())
+	assert.Equal(t, 22, o.sshPort())
+	assert.NotNil(t, o.dialer())
+}
+
+func TestFinalizeOptions_Overrides(t *testing.T) {
+	o := FinalizeOptions{Timeout: 5 * time.Minute, PollInterval: time.Second, SSHPort: 2222}
+	assert.Equal(t, 5*time.Minute, o.timeout())
+	assert.Equal(t, time.Second, o.pollInterval())
+	assert.Equal(t, 2222, o.sshPort())
+}
+
+// Sanity: confirm SSH banner detection prefix-matches just the literal "SSH-".
+func TestSSHBannerPrefix(t *testing.T) {
+	assert.True(t, strings.HasPrefix("SSH-2.0-OpenSSH", "SSH-"))
+	assert.False(t, strings.HasPrefix("HTTP/1.1", "SSH-"))
+}
+
+// TestFinalizeSingle_IssuesExpectedQMSets verifies that FinalizeSingle issues
+// (in order) ide3 detach, ide2 detach, and boot-order=order=scsi0 against the
+// Proxmox API.
+func TestFinalizeSingle_IssuesExpectedQMSets(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		bodies   []url.Values
+		paths    []string
+		methods  []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// API token auth: skip /access/ticket — token-based client doesn't hit it.
+		if strings.Contains(r.URL.Path, "/tasks/") {
+			_, _ = io.WriteString(w, `{"data":{"status":"stopped","exitstatus":"OK"}}`)
+			return
+		}
+		raw, _ := io.ReadAll(r.Body)
+		body, _ := url.ParseQuery(string(raw))
+		mu.Lock()
+		bodies = append(bodies, body)
+		paths = append(paths, r.URL.Path)
+		methods = append(methods, r.Method)
+		mu.Unlock()
+		_, _ = io.WriteString(w, `{"data":null}`)
+	}))
+	defer srv.Close()
+
+	c, err := proxmox.NewClient(proxmox.ClientOpts{
+		Endpoint:    srv.URL,
+		TokenID:     "root@pam!test",
+		TokenSecret: "secret",
+		InsecureTLS: true,
+		Timeout:     5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, FinalizeSingle(context.Background(), c, "pve", 2701))
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Len(t, bodies, 3, "expected 3 config writes (ide3 detach, ide2 detach, boot order)")
+	for _, m := range methods {
+		assert.Equal(t, http.MethodPost, m)
+	}
+	for _, p := range paths {
+		assert.Contains(t, p, "/nodes/pve/qemu/2701/config")
+	}
+	assert.Equal(t, "ide3", bodies[0].Get("delete"), "first call detaches ide3 (kickstart)")
+	assert.Equal(t, "ide2", bodies[1].Get("delete"), "second call detaches ide2 (install)")
+	assert.Equal(t, "order=scsi0", bodies[2].Get("boot"), "third call resets boot order to scsi0")
+}
+
+func TestFinalizeSingle_NilClient(t *testing.T) {
+	err := FinalizeSingle(context.Background(), nil, "pve", 100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Client not set")
+}

--- a/pkg/workflow/multi_node.go
+++ b/pkg/workflow/multi_node.go
@@ -39,6 +39,11 @@ type MultiNodeWorkflow struct {
 	// SkipKickstartBuild propagates to every per-node SingleVMWorkflow. See
 	// SingleVMWorkflow.SkipKickstartBuild.
 	SkipKickstartBuild bool
+	// SkipFinalize disables the post-install finalize step (SSH-up wait +
+	// detach ide2/ide3 + reset boot order). Default false. See #67.
+	SkipFinalize bool
+	// FinalizeOptions tunes the finalize step. Zero-value uses defaults.
+	FinalizeOptions FinalizeOptions
 }
 
 // NewMultiNodeWorkflow is a small factory that fills sensible defaults.
@@ -91,6 +96,8 @@ func (m *MultiNodeWorkflow) perNode(name string) *SingleVMWorkflow {
 		DryRun:             m.DryRun,
 		UploadMu:           m.isoMu(),
 		SkipKickstartBuild: m.SkipKickstartBuild,
+		SkipFinalize:       m.SkipFinalize,
+		FinalizeOptions:    m.FinalizeOptions,
 	}
 }
 
@@ -273,6 +280,11 @@ func (m *MultiNodeWorkflow) Up(ctx context.Context) error {
 	}
 	if err := m.Verify(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "warn: verify: %v\n", err)
+	}
+	if !m.SkipFinalize && !m.DryRun {
+		if err := m.Finalize(ctx); err != nil {
+			return fmt.Errorf("finalize: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/workflow/multi_node_test.go
+++ b/pkg/workflow/multi_node_test.go
@@ -228,6 +228,7 @@ func TestMultiNode_Up_HappyPath(t *testing.T) {
 	defer srv.Close()
 	rnd, _ := kickstart.NewRenderer()
 	m := NewMultiNodeWorkflow(testMultiEnv(), p.client(t, srv), rnd, stubISOBuilder(t))
+	m.SkipFinalize = true // Up tests don't simulate SSH; finalize is exercised separately.
 	if err := m.Up(context.Background()); err != nil {
 		t.Fatalf("Up: %v", err)
 	}

--- a/pkg/workflow/single_vm.go
+++ b/pkg/workflow/single_vm.go
@@ -41,6 +41,13 @@ type SingleVMWorkflow struct {
 	// out-of-band (e.g. an OEMDRV-labeled ISO), or when iterating on VM
 	// hardware config without re-rendering kickstart. See #23.
 	SkipKickstartBuild bool
+	// SkipFinalize disables the post-install finalize step (SSH-up wait +
+	// detach ide2/ide3 + reset boot order to scsi0). Default false — finalize
+	// runs as part of Up. See #67.
+	SkipFinalize bool
+	// FinalizeOptions tunes the finalize step (SSH-up timeout, poll interval,
+	// dialer for tests). Zero-value uses sane production defaults.
+	FinalizeOptions FinalizeOptions
 }
 
 // resolved pulls commonly-accessed nested structures from the env.
@@ -311,6 +318,14 @@ func (w *SingleVMWorkflow) Up(ctx context.Context) error {
 	// Verify is best-effort — the VM may still be booting when we return.
 	if err := w.Verify(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "warn: verify: %v\n", err)
+	}
+	// Finalize: wait for SSH-up, detach install/kickstart ISOs, reset boot
+	// order. Mandatory for kickstart-installed VMs to avoid the install loop
+	// (#67). Operators iterating on hardware can opt-out via SkipFinalize.
+	if !w.SkipFinalize && !w.DryRun {
+		if err := w.Finalize(ctx); err != nil {
+			return fmt.Errorf("finalize: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/workflow/single_vm_test.go
+++ b/pkg/workflow/single_vm_test.go
@@ -639,6 +639,7 @@ func TestUp(t *testing.T) {
 	w := &SingleVMWorkflow{
 		Config: testEnv(), NodeName: "web01", Client: state.client(t, srv),
 		Renderer: rnd, Builder: stubISOBuilder(t),
+		SkipFinalize: true, // finalize requires SSH-up; tested separately.
 	}
 	if err := w.Up(context.Background()); err != nil {
 		t.Errorf("Up: %v", err)
@@ -711,6 +712,7 @@ func TestUp_VerifyWarns(t *testing.T) {
 			return c
 		}(),
 		Renderer: rnd, Builder: stubISOBuilder(t),
+		SkipFinalize: true,
 	}
 	// Up should return nil despite verify warning.
 	if err := w.Up(context.Background()); err != nil {


### PR DESCRIPTION
Closes #67.

## Summary

Fixes the kickstart install-loop bug confirmed live during ext3 Stage 2 on 2026-05-04 (VMs 2701/2702). After Anaconda finishes the install on scsi0 and reboots, ide3 (kickstart ISO) is still attached + bootable; with ide3 ahead of scsi0 in the boot order (required for the *first* boot), BIOS re-enters the kickstart ISO → install loop.

## What changed

Adds a finalize step to the `workflow` lifecycle:

1. Poll for SSH-up on the node's management/public IP (TCP connect to :22 + SSH banner check), default 30 min timeout.
2. Detach ide3 (kickstart ISO) and ide2 (install ISO) via `qm set <vmid> -delete <slot>`.
3. Reset boot order to `order=scsi0` (single device).

CLI:
- New `proxctl workflow finalize` subcommand (single + multi-node).
- `proxctl workflow up` runs finalize automatically; opt-out via `--skip-finalize`.
- `--finalize-timeout <duration>` overrides default 30m wait.

## Test plan

- [x] `go test ./...` passes (full suite, 120s timeout).
- [x] Unit tests cover: SSH banner detection, retry-until-banner, timeout error, no-IP error, SkipSSHWait mode, non-SSH banner ignored, IP priority (management → public → private → any), defaults/overrides.
- [x] httptest integration test asserts exact qm-set sequence: delete ide3 → delete ide2 → boot=order=scsi0.
- [x] `proxctl workflow finalize --help` and `proxctl workflow up --help --skip-finalize` print expected help.
- [x] Existing happy-path Up tests opt-out of finalize (`SkipFinalize: true`) since they don't simulate a live SSH endpoint.
- [ ] Live test: next provisioning run (NOT 2701/2702 which are mid-install) reaches `running` without operator intervention on boot order.

## Idempotency

`EjectISO` posts `delete=ideN` which Proxmox returns 200 + null for both present and absent slots, so re-running `workflow finalize` on already-finalised VMs is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)