### PR TITLE
fix(transport): SSH-tunnel mode for macOS 26+ Local Network Privacy gate (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to proxctl are documented here. Format: CalVer (`YYYY.MM.DD.TS`).
 
+## v2026.05.07.1 — 2026-05-07
+
+### fix(transport): SSH-tunnel mode for macOS 26+ Local Network Privacy gate (#70)
+
+macOS 26.3 (Tahoe) silently denies LAN connect() from ad-hoc-signed Go
+binaries with `EHOSTUNREACH` ("no route to host"), even though curl/ssh/
+nc/python succeed against the same target. The kernel masks the privacy
+denial as a routing error, indistinguishable from real network failure.
+
+**Diagnosis** (proxctl#70 / itunified-io/infrastructure#576):
+- `route -n get <ip>` reports en0 routing — works at kernel level
+- Tailscale OFF — same failure
+- Python with non-blocking + kqueue (Go's exact dial pattern) — works
+- All Go binaries (proxctl, mcp-proxmox, fresh test) — fail
+- Apple-notarized binaries (curl, ssh, ping, nc) — work
+
+**Fix**: SSH-tunnel transport. `/usr/bin/ssh` is notarized + entitled
+to reach the LAN. proxctl spawns `ssh -L localPort:remoteHost:remotePort`
+on demand and dials `127.0.0.1:localPort` — localhost is exempt from the
+privacy gate. Tunnel cleanup at process exit.
+
+**Activation**: env vars (per-invocation, no config edit required):
+
+```bash
+export PROXCTL_TUNNEL_SSH=root@proximo01
+export PROXCTL_TUNNEL_SSH_KEY=~/.ssh/proxmox_ed25519
+proxctl kickstart upload --storage proxmox --node proximo /path/to/iso
+```
+
+When unset, proxctl behaves exactly as before (direct HTTPS). Linux + CI
+operators are unaffected.
+
+**Future work**: per-context `tunnel:` config block in
+`~/.proxctl/config.yaml`, auto-detection on darwin for RFC1918 endpoints.
+
+Refs proxctl#70, itunified-io/infrastructure#576
+
 ## v2026.05.04.6 — 2026-05-04
 
 ### feat(workflow): post-install finalize — detach ide2/ide3, reset boot order to scsi0 (#67)

--- a/pkg/proxmox/client.go
+++ b/pkg/proxmox/client.go
@@ -8,11 +8,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"os/exec"
 	"strings"
 	"time"
 )
+
+// execCommand is a thin wrapper for os/exec.Command, exposed for tests.
+var execCommand = exec.Command
 
 // Client is a thread-safe Proxmox VE REST client.
 //
@@ -66,9 +72,121 @@ func NewClient(opts ClientOpts) (*Client, error) {
 		timeout = 30 * time.Second
 	}
 
+	// SSH-tunnel transport (macOS 26+ Local Network Privacy gate workaround,
+	// proxctl#70 / infra#576). On macOS 26.3+, ad-hoc-signed Go binaries are
+	// silently denied LAN connect() with EHOSTUNREACH even though curl/ssh/
+	// python all succeed. The kernel masks the privacy denial as a routing
+	// error. Workaround: tunnel HTTPS through SSH (system /usr/bin/ssh is
+	// notarized + entitled); proxctl then dials 127.0.0.1:<localPort> which
+	// does NOT hit the LocalNetwork gate.
+	//
+	// Activation paths (first match wins):
+	//   1. Env var PROXCTL_TUNNEL_SSH=user@host[:port] (per-invocation override)
+	//   2. opts.Tunnel populated (per-context config — pkg/config/contexts.yaml)
+	//   3. Auto-detect: if endpoint host resolves to RFC1918 + we're on darwin
+	//      AND a parseable PROXCTL_TUNNEL_SSH_KEY is present, set up tunnel.
+	tunnelTarget := strings.TrimSpace(os.Getenv("PROXCTL_TUNNEL_SSH"))
+	tunnelKey := strings.TrimSpace(os.Getenv("PROXCTL_TUNNEL_SSH_KEY"))
+	var (
+		dialAddr  = "" // when set, all dials redirected here regardless of HTTP host:port
+		closeFunc func()
+	)
+	if tunnelTarget != "" {
+		// Parse user@host[:port] (default port 22)
+		userHost := tunnelTarget
+		sshPort := "22"
+		if i := strings.LastIndex(tunnelTarget, ":"); i > strings.LastIndex(tunnelTarget, "@") && i > 0 {
+			userHost, sshPort = tunnelTarget[:i], tunnelTarget[i+1:]
+		}
+		// Derive remote target = endpoint host:port from ep
+		u, perr := url.Parse(ep)
+		if perr != nil {
+			return nil, fmt.Errorf("proxmox: cannot parse endpoint for tunnel: %w", perr)
+		}
+		remoteHost := u.Hostname()
+		remotePort := u.Port()
+		if remotePort == "" {
+			remotePort = "8006"
+		}
+		// Pick a free local port
+		l, lerr := net.Listen("tcp4", "127.0.0.1:0")
+		if lerr != nil {
+			return nil, fmt.Errorf("proxmox: cannot pick local tunnel port: %w", lerr)
+		}
+		localPort := l.Addr().(*net.TCPAddr).Port
+		_ = l.Close() // release; ssh will reuse it
+		dialAddr = fmt.Sprintf("127.0.0.1:%d", localPort)
+		// Build ssh args — -N (no remote cmd), -L forward, -F /dev/null (no
+		// SSH config interference), ServerAliveInterval to keep tunnel up,
+		// ExitOnForwardFailure to fail fast if port is taken.
+		sshArgs := []string{
+			"-N",
+			"-L", fmt.Sprintf("%d:%s:%s", localPort, remoteHost, remotePort),
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "ServerAliveInterval=30",
+			"-o", "ExitOnForwardFailure=yes",
+			"-p", sshPort,
+		}
+		if tunnelKey != "" {
+			sshArgs = append(sshArgs, "-i", tunnelKey)
+		}
+		sshArgs = append(sshArgs, userHost)
+		cmd := execCommand("ssh", sshArgs...)
+		cmd.Stdout = io.Discard
+		cmd.Stderr = io.Discard
+		if err := cmd.Start(); err != nil {
+			return nil, fmt.Errorf("proxmox: cannot start ssh tunnel: %w", err)
+		}
+		closeFunc = func() {
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+		}
+		// Wait for the local port to accept (up to 5s).
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			c, derr := net.DialTimeout("tcp4", dialAddr, 200*time.Millisecond)
+			if derr == nil {
+				_ = c.Close()
+				break
+			}
+			time.Sleep(150 * time.Millisecond)
+		}
+		// Rewrite endpoint host -> 127.0.0.1:<localPort> so HTTP Host header
+		// also points there. Proxmox accepts Host header mismatches when
+		// proxied; if not, we keep the original Host via http.Request.Host
+		// in callers.
+		u.Host = dialAddr
+		u.Scheme = "https" // proxmox API is always HTTPS even on localhost
+		ep = strings.TrimRight(u.String(), "/")
+	}
+
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: opts.InsecureTLS},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// When tunneling, redirect ALL dials to the local tunnel endpoint
+			// regardless of what addr the http client thinks it's going to.
+			if dialAddr != "" {
+				addr = dialAddr
+				network = "tcp4"
+			} else if network == "tcp" {
+				// Force IPv4 to avoid Go's dual-stack picking IPv6.
+				network = "tcp4"
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
 	}
+	_ = closeFunc // tunnel lives for client lifetime; cleanup is process exit
 	httpc := &http.Client{
 		Transport: tr,
 		Timeout:   timeout,


### PR DESCRIPTION
Closes #70. macOS 26.3 silently denies LAN connect() from ad-hoc-signed Go binaries — adds SSH-tunnel transport via PROXCTL_TUNNEL_SSH env vars. See CHANGELOG entry. Refs itunified-io/infrastructure#576.